### PR TITLE
Publish OCM registry server image to ghcr.io

### DIFF
--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -7,6 +7,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  REGISTRY_IMAGE_NAME: open-component-model/ocm-registry-server
 
 jobs:
   build-and-push:
@@ -32,6 +33,35 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-and-push-registry:
+    runs-on: "ubuntu-latest"
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          file: registry-server.dockerfile
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Description

This PR ensures that the registry server image is also published when we ship the ocm-controller image.

Signed-off-by: Piaras Hoban <phoban01@gmail.com>