### PR TITLE
Change Registry Image Name

### DIFF
--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -7,7 +7,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  REGISTRY_IMAGE_NAME: open-component-model/ocm-registry-server
+  REGISTRY_IMAGE_NAME: open-component-model/ocm-registry
 
 jobs:
   build-and-push:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/open-component-model/ocm-controller
 # Registry server image URL to use all building/pushing image targets
-REG_IMG ?= ghcr.io/open-component-model/ocm-registry-server
+REG_IMG ?= ghcr.io/open-component-model/ocm-registry
 TAG ?= latest
 REG_TAG ?= latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
@@ -103,7 +103,7 @@ docker-registry-server:
 	.
 
 .PHONY: docker-registry-server-push
-docker-registry-server-push: ## Push docker image with the manager.
+docker-registry-server-push: docker-registry-server ## Push docker image with the manager.
 	docker push ${REG_IMG}:${REG_TAG}
 
 ##@ Deployment

--- a/config/default/patches/init-container.yaml
+++ b/config/default/patches/init-container.yaml
@@ -12,5 +12,5 @@ spec:
     spec:
       initContainers:
         - name: init-registry
-          image: open-component-model/ocm-registry-server
+          image: open-component-model/ocm-registry
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Description

Due to an issue with the ghcr we are unable push an image to `open-component-model/ocm-registry-server`. To sidestep this and unblock users we are changing the name of the container repository to `open-component-model/ocm-registry`.

Signed-off-by: Piaras Hoban <phoban01@gmail.com>
