### PR TITLE
Fix verification process

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/mitchellh/hashstructure v1.1.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/gomega v1.24.1
-	github.com/open-component-model/ocm v0.1.0-alpha.2
+	github.com/open-component-model/ocm v0.0.1-0.20230125120944-4c043d3c2263
 	github.com/open-component-model/ocm-controllers-sdk v0.0.6
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc2

--- a/go.sum
+++ b/go.sum
@@ -959,8 +959,8 @@ github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDs
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.24.1 h1:KORJXNNTzJXzu4ScJWssJfJMnJ+2QJqhoQSRwNlze9E=
 github.com/onsi/gomega v1.24.1/go.mod h1:3AOiACssS3/MajrniINInwbfOOtfZvplPzuRSmvt1jM=
-github.com/open-component-model/ocm v0.1.0-alpha.2 h1:69v/JRYspBNJA6Z/epQP47y5vUawyfu96g67aOY0pTM=
-github.com/open-component-model/ocm v0.1.0-alpha.2/go.mod h1:aPlBtHOXiAVG9wy7vL1fIwwEjJwB0HMk5n16JlI5k2o=
+github.com/open-component-model/ocm v0.0.1-0.20230125120944-4c043d3c2263 h1:E5awouDL25JB7TEkaD+8UoydEFABmVRxYCRho8pJF4s=
+github.com/open-component-model/ocm v0.0.1-0.20230125120944-4c043d3c2263/go.mod h1:aPlBtHOXiAVG9wy7vL1fIwwEjJwB0HMk5n16JlI5k2o=
 github.com/open-component-model/ocm-controllers-sdk v0.0.6 h1:EriZ9IhYfVyPfvvglLRSUlBuxXt9aQIlfl2vgMhz2Ww=
 github.com/open-component-model/ocm-controllers-sdk v0.0.6/go.mod h1:npwcEnReNGiZ8DAJ5WEpcmenGWqHhMUHbN0040oS/CM=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -12,7 +12,6 @@ import (
 	"sort"
 
 	"github.com/Masterminds/semver"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/utils"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -208,8 +207,6 @@ func (c *Client) VerifyComponent(ctx context.Context, obj *v1alpha1.ComponentVer
 			signing.VerifyDigests(),
 			signing.VerifySignature(signature.Name),
 		)
-
-		opts.NormalizationAlgo = compdesc.JsonNormalisationV2
 
 		if err := opts.Complete(signingattr.Get(octx)); err != nil {
 			return false, fmt.Errorf("verify error: %w", err)

--- a/pkg/ocm/setup_test.go
+++ b/pkg/ocm/setup_test.go
@@ -153,7 +153,7 @@ func (t *testEnv) AddComponentVersionToRepository(component Component, resources
 			signing.PrivateKey(component.Sign.Name, component.Sign.Key),
 			signing.Update(), signing.VerifyDigests(),
 		)
-		opts.NormalizationAlgo = compdesc.JsonNormalisationV2
+
 		if err := opts.Complete(signingattr.Get(octx)); err != nil {
 			return fmt.Errorf("failed to complete signing: %w", err)
 		}


### PR DESCRIPTION
The problem was that ocm-contoller was using an OCM version from 2022 December. However, this also means that the changes made in OCM weren't backward compatible regarding signing. We have to keep an eye out for that.

The second part is that we were setting the signing algorithm to V2 in the code. This will fail if the signing on the outside is set to V1 or not set, as it defaults to V1. Perhaps we should expose this setting in the CRD.