### PR TITLE
Add workflow_call to test GA workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,6 +6,7 @@ on:
       - 'CODE_OF_CONDUCT.md'
       - 'README.md'
       - 'Contributing.md'
+  workflow_call:
 
   push:
     branches:


### PR DESCRIPTION
This PR adds a `workflow_call` for the `tests.yaml` workflow so that it can be called from the release workflow :)