### PR TITLE
Change goreleaser runtime variable for docker

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,4 +28,6 @@ changelog:
       - '^docs:'
       - '^test:'
 dockers:
-  - image_templates: ["{{ .Env.REGISTRY }}/open-component-model/{{ .ProjectName }}:{{ .Version }}-{{ .Arch }}"]
+  - image_templates: ["{{ .Env.REGISTRY }}/open-component-model/{{ .ProjectName }}:{{ .Version }}"]
+    build_flag_templates:
+    - "--platform=linux/amd64"


### PR DESCRIPTION
The variable `{ .Arch }` is not available for the `dockers` field, only for building the binary. Instead, `{ runtime.Goarch }` is available everywhere. Tested this with the goreleaser CLI and it went through.