### PR TITLE
ref: make verify an optional field

### DIFF
--- a/api/v1alpha1/componentversion_types.go
+++ b/api/v1alpha1/componentversion_types.go
@@ -65,8 +65,8 @@ type ComponentVersionSpec struct {
 	// +required
 	Repository Repository `json:"repository"`
 
-	// +required
-	Verify []Signature `json:"verify"`
+	// +optional
+	Verify []Signature `json:"verify,omitempty"`
 
 	// +optional
 	References ReferencesConfig `json:"references,omitempty"`

--- a/config/crd/bases/delivery.ocm.software_componentversions.yaml
+++ b/config/crd/bases/delivery.ocm.software_componentversions.yaml
@@ -111,7 +111,6 @@ spec:
             - component
             - interval
             - repository
-            - verify
             - version
             type: object
           status:


### PR DESCRIPTION
It's technically already optional anyways, since it's a slice that is allowed to be empty.