### PR TITLE
feat: add source and configuration snapshot check to shouldReconcile

### DIFF
--- a/api/v1alpha1/mutation_types.go
+++ b/api/v1alpha1/mutation_types.go
@@ -94,10 +94,15 @@ type MutationStatus struct {
 	// +optional
 	LastAppliedSourceDigest string `json:"lastAppliedSourceDigest,omitempty"`
 
-	// LastAppliedSourceTag defines the last seen source tag that has been encountered
+	// LastAppliedConfigSourceDigest defines the last seen config source digest that has been encountered
 	// by this object. Only applicable if Source is a SourceRef.
 	// +optional
-	LastAppliedSourceTag string `json:"lastAppliedSourceTag,omitempty"`
+	LastAppliedConfigSourceDigest string `json:"lastAppliedConfigSourceDigest,omitempty"`
+
+	// LastAppliedPatchMergeSourceDigest defines the last seen patch merge source digest that has been encountered
+	// by this object. Only applicable if Source is a SourceRef.
+	// +optional
+	LastAppliedPatchMergeSourceDigest string `json:"lastAppliedPatchMergeSourceDigest,omitempty"`
 }
 
 type ConfigReference struct {

--- a/api/v1alpha1/mutation_types.go
+++ b/api/v1alpha1/mutation_types.go
@@ -88,6 +88,16 @@ type MutationStatus struct {
 	// we fire off a reconcile loop to get that new version.
 	// +optional
 	LastAppliedComponentVersion string `json:"lastAppliedComponentVersion,omitempty"`
+
+	// LastAppliedSourceDigest defines the last seen source digest that has been encountered
+	// by this object. Only applicable if Source is a SourceRef.
+	// +optional
+	LastAppliedSourceDigest string `json:"lastAppliedSourceDigest,omitempty"`
+
+	// LastAppliedSourceTag defines the last seen source tag that has been encountered
+	// by this object. Only applicable if Source is a SourceRef.
+	// +optional
+	LastAppliedSourceTag string `json:"lastAppliedSourceTag,omitempty"`
 }
 
 type ConfigReference struct {

--- a/config/crd/bases/delivery.ocm.software_configurations.yaml
+++ b/config/crd/bases/delivery.ocm.software_configurations.yaml
@@ -319,6 +319,16 @@ spec:
                   version. If there is a change we fire off a reconcile loop to get
                   that new version.
                 type: string
+              lastAppliedSourceDigest:
+                description: LastAppliedSourceDigest defines the last seen source
+                  digest that has been encountered by this object. Only applicable
+                  if Source is a SourceRef.
+                type: string
+              lastAppliedSourceTag:
+                description: LastAppliedSourceTag defines the last seen source tag
+                  that has been encountered by this object. Only applicable if Source
+                  is a SourceRef.
+                type: string
               latestConfigVersion:
                 type: string
               latestSnapshotDigest:

--- a/config/crd/bases/delivery.ocm.software_configurations.yaml
+++ b/config/crd/bases/delivery.ocm.software_configurations.yaml
@@ -319,15 +319,20 @@ spec:
                   version. If there is a change we fire off a reconcile loop to get
                   that new version.
                 type: string
+              lastAppliedConfigSourceDigest:
+                description: LastAppliedConfigSourceDigest defines the last seen config
+                  source digest that has been encountered by this object. Only applicable
+                  if Source is a SourceRef.
+                type: string
+              lastAppliedPatchMergeSourceDigest:
+                description: LastAppliedPatchMergeSourceDigest defines the last seen
+                  patch merge source digest that has been encountered by this object.
+                  Only applicable if Source is a SourceRef.
+                type: string
               lastAppliedSourceDigest:
                 description: LastAppliedSourceDigest defines the last seen source
                   digest that has been encountered by this object. Only applicable
                   if Source is a SourceRef.
-                type: string
-              lastAppliedSourceTag:
-                description: LastAppliedSourceTag defines the last seen source tag
-                  that has been encountered by this object. Only applicable if Source
-                  is a SourceRef.
                 type: string
               latestConfigVersion:
                 type: string

--- a/config/crd/bases/delivery.ocm.software_localizations.yaml
+++ b/config/crd/bases/delivery.ocm.software_localizations.yaml
@@ -319,6 +319,16 @@ spec:
                   version. If there is a change we fire off a reconcile loop to get
                   that new version.
                 type: string
+              lastAppliedSourceDigest:
+                description: LastAppliedSourceDigest defines the last seen source
+                  digest that has been encountered by this object. Only applicable
+                  if Source is a SourceRef.
+                type: string
+              lastAppliedSourceTag:
+                description: LastAppliedSourceTag defines the last seen source tag
+                  that has been encountered by this object. Only applicable if Source
+                  is a SourceRef.
+                type: string
               latestConfigVersion:
                 type: string
               latestSnapshotDigest:

--- a/config/crd/bases/delivery.ocm.software_localizations.yaml
+++ b/config/crd/bases/delivery.ocm.software_localizations.yaml
@@ -319,15 +319,20 @@ spec:
                   version. If there is a change we fire off a reconcile loop to get
                   that new version.
                 type: string
+              lastAppliedConfigSourceDigest:
+                description: LastAppliedConfigSourceDigest defines the last seen config
+                  source digest that has been encountered by this object. Only applicable
+                  if Source is a SourceRef.
+                type: string
+              lastAppliedPatchMergeSourceDigest:
+                description: LastAppliedPatchMergeSourceDigest defines the last seen
+                  patch merge source digest that has been encountered by this object.
+                  Only applicable if Source is a SourceRef.
+                type: string
               lastAppliedSourceDigest:
                 description: LastAppliedSourceDigest defines the last seen source
                   digest that has been encountered by this object. Only applicable
                   if Source is a SourceRef.
-                type: string
-              lastAppliedSourceTag:
-                description: LastAppliedSourceTag defines the last seen source tag
-                  that has been encountered by this object. Only applicable if Source
-                  is a SourceRef.
                 type: string
               latestConfigVersion:
                 type: string

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -198,16 +198,21 @@ func (r *ConfigurationReconciler) shouldReconcile(ctx context.Context, cv *v1alp
 
 	// if source is a snapshot, check on its status
 	if obj.Spec.Source.SourceRef != nil {
-		snapshot := &v1alpha1.Snapshot{}
-		if err := r.Get(ctx, types.NamespacedName{
-			Namespace: obj.Spec.Source.SourceRef.Namespace,
-			Name:      obj.Spec.Source.SourceRef.Name,
-		}, snapshot); err != nil {
-			return false, err
-		}
+		switch obj.Spec.Source.SourceRef.Kind {
+		case "Snapshot":
+			snapshot := &v1alpha1.Snapshot{}
+			if err := r.Get(ctx, types.NamespacedName{
+				Namespace: obj.Spec.Source.SourceRef.Namespace,
+				Name:      obj.Spec.Source.SourceRef.Name,
+			}, snapshot); err != nil {
+				return false, err
+			}
 
-		if obj.Status.LastAppliedSourceDigest != snapshot.Status.LastReconciledDigest || obj.Status.LastAppliedSourceTag != snapshot.Status.LastReconciledTag {
-			return true, nil
+			if obj.Status.LastAppliedSourceDigest != snapshot.Status.LastReconciledDigest || obj.Status.LastAppliedSourceTag != snapshot.Status.LastReconciledTag {
+				return true, nil
+			}
+		default:
+			return false, fmt.Errorf("kind not supported for source object: %s", obj.Spec.Source.SourceRef.Kind)
 		}
 	}
 
@@ -263,7 +268,8 @@ func (r *ConfigurationReconciler) reconcile(ctx context.Context, cv *v1alpha1.Co
 
 	if obj.Spec.Source.SourceRef != nil {
 		// For now, we only support setting last digest from Snapshot type source objects.
-		if obj.Spec.Source.SourceRef.Kind == "Snapshot" {
+		switch obj.Spec.Source.SourceRef.Kind {
+		case "Snapshot":
 			snapshot := &v1alpha1.Snapshot{}
 			if err := r.Get(ctx, types.NamespacedName{
 				Namespace: obj.Spec.Source.SourceRef.Namespace,
@@ -274,6 +280,8 @@ func (r *ConfigurationReconciler) reconcile(ctx context.Context, cv *v1alpha1.Co
 
 			obj.Status.LastAppliedSourceDigest = snapshot.Status.LastReconciledDigest
 			obj.Status.LastAppliedSourceTag = snapshot.Status.LastReconciledTag
+		default:
+			return ctrl.Result{}, fmt.Errorf("kind not supported for source object: %s", obj.Spec.Source.SourceRef.Kind)
 		}
 	}
 

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -102,6 +103,11 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	run, err := r.shouldReconcile(ctx, componentVersion, obj)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("source snapshot not yet available; skip reconcile for object", "object", klog.KObj(obj))
+			result, retErr = ctrl.Result{RequeueAfter: obj.GetRequeueAfter()}, nil
+			return result, retErr
+		}
 		retErr = fmt.Errorf("failed to check if controller should reconcile: %w", err)
 		return result, retErr
 	}
@@ -179,12 +185,30 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 //     update; the reconciliation should _PROCEED_
 //
 // If neither of these cases match, the reconciliation should _STOP_ and requeue the object.
+// For mutating objects, we include two other checks. These objects can have a Source object defined as a Snapshot.
+// We also want to track the condition of those source objects. If the last seen digest or tag of those Snapshots
+// changed, we should reconcile and see if there is anything new we need to apply.
 func (r *ConfigurationReconciler) shouldReconcile(ctx context.Context, cv *v1alpha1.ComponentVersion, obj *v1alpha1.Configuration) (bool, error) {
 	// If there is a mismatch between the observed generation of a component version, we trigger
 	// a reconcile. There is either a new version available or a dependent component version
 	// finished its reconcile process.
 	if obj.Status.LastAppliedComponentVersion != cv.Status.ReconciledVersion {
 		return true, nil
+	}
+
+	// if source is a snapshot, check on its status
+	if obj.Spec.Source.SourceRef != nil {
+		snapshot := &v1alpha1.Snapshot{}
+		if err := r.Get(ctx, types.NamespacedName{
+			Namespace: obj.Spec.Source.SourceRef.Namespace,
+			Name:      obj.Spec.Source.SourceRef.Name,
+		}, snapshot); err != nil {
+			return false, err
+		}
+
+		if obj.Status.LastAppliedSourceDigest != snapshot.Status.LastReconciledDigest || obj.Status.LastAppliedSourceTag != snapshot.Status.LastReconciledTag {
+			return true, nil
+		}
 	}
 
 	// If there is no mismatch, we check if we are already done with our snapshot.
@@ -236,6 +260,22 @@ func (r *ConfigurationReconciler) reconcile(ctx context.Context, cv *v1alpha1.Co
 	}
 	obj.Status.ObservedGeneration = obj.GetGeneration()
 	obj.Status.LastAppliedComponentVersion = cv.Status.ReconciledVersion
+
+	if obj.Spec.Source.SourceRef != nil {
+		// For now, we only support setting last digest from Snapshot type source objects.
+		if obj.Spec.Source.SourceRef.Kind == "Snapshot" {
+			snapshot := &v1alpha1.Snapshot{}
+			if err := r.Get(ctx, types.NamespacedName{
+				Namespace: obj.Spec.Source.SourceRef.Namespace,
+				Name:      obj.Spec.Source.SourceRef.Name,
+			}, snapshot); err != nil {
+				return ctrl.Result{RequeueAfter: obj.GetRequeueAfter()}, err
+			}
+
+			obj.Status.LastAppliedSourceDigest = snapshot.Status.LastReconciledDigest
+			obj.Status.LastAppliedSourceTag = snapshot.Status.LastReconciledTag
+		}
+	}
 
 	// Remove any stale Ready condition, most likely False, set above. Its value
 	// is derived from the overall result of the reconciliation in the deferred

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -627,10 +627,9 @@ configuration:
 				gitRepo := createGitRepository("patch-repo", "default", server.URL()+path, checksum)
 				configuration = tt.patchStrategicMerge(configuration, gitRepo, "sites/eu-west-1/deployment.yaml")
 				objs = append(objs, gitRepo)
-				sourcev1.AddToScheme(env.scheme)
 			}
 
-			client := env.FakeKubeClient(WithObjets(objs...))
+			client := env.FakeKubeClient(WithObjets(objs...), WithAddToScheme(sourcev1.AddToScheme))
 			cache := &cachefakes.FakeCache{}
 			fakeOcm := &fakes.MockFetcher{}
 			tt.mock(cache, fakeOcm)
@@ -973,13 +972,11 @@ func TestConfigurationShouldReconcile(t *testing.T) {
 
 	for i, tt := range testcase {
 		t.Run(fmt.Sprintf("%d: %s", i, tt.name), func(t *testing.T) {
-			// We don't set a source because it shouldn't get that far.
 			var objs []client.Object
 			configuration := tt.configuration(&objs)
 			cv := tt.componentVersion()
 			objs = append(objs, cv)
-			v1beta2.AddToScheme(env.scheme)
-			client := env.FakeKubeClient(WithObjets(objs...))
+			client := env.FakeKubeClient(WithObjets(objs...), WithAddToScheme(v1beta2.AddToScheme))
 			cache := &cachefakes.FakeCache{}
 			fakeOcm := &fakes.MockFetcher{}
 

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/runtime/conditions"
+	"github.com/fluxcd/source-controller/api/v1beta2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 	"github.com/onsi/gomega/ghttp"
 	"github.com/stretchr/testify/assert"
@@ -827,8 +828,10 @@ func TestConfigurationShouldReconcile(t *testing.T) {
 						Name:      name,
 						Namespace: namespace,
 					},
-					Spec:   v1alpha1.SnapshotSpec{},
-					Status: v1alpha1.SnapshotStatus{},
+					Spec: v1alpha1.SnapshotSpec{},
+					Status: v1alpha1.SnapshotStatus{
+						LastReconciledDigest: "last-reconciled-digest",
+					},
 				}
 				conditions.MarkTrue(snapshot, meta.ReadyCondition, meta.SucceededReason, "Snapshot with name '%s' is ready", snapshot.Name)
 				return snapshot
@@ -837,7 +840,6 @@ func TestConfigurationShouldReconcile(t *testing.T) {
 				configuration := DefaultConfiguration.DeepCopy()
 				configuration.Status.LastAppliedComponentVersion = "v0.0.1"
 				configuration.Status.LastAppliedSourceDigest = "last-reconciled-digest"
-				configuration.Status.LastAppliedSourceTag = "latest"
 				configuration.Spec.Source.SourceRef = &meta.NamespacedObjectKindReference{
 					Kind:      "Snapshot",
 					Name:      "source-snapshot",
@@ -908,6 +910,10 @@ func TestConfigurationShouldReconcile(t *testing.T) {
 func createGitRepository(name, namespace, artifactURL, checksum string) *sourcev1.GitRepository {
 	updatedTime := time.Now()
 	return &sourcev1.GitRepository{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "GitRepository",
+			APIVersion: v1beta2.GroupVersion.String(),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,

--- a/controllers/localization_controller.go
+++ b/controllers/localization_controller.go
@@ -13,11 +13,11 @@ import (
 	"time"
 
 	"github.com/fluxcd/pkg/runtime/patch"
+	"github.com/fluxcd/source-controller/api/v1beta2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -104,17 +104,12 @@ func (r *LocalizationReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	run, err := r.shouldReconcile(ctx, componentVersion, obj)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info("source snapshot not yet available; skip reconcile for object", "object", klog.KObj(obj))
-			result, retErr = ctrl.Result{RequeueAfter: obj.GetRequeueAfter()}, nil
-			return result, retErr
-		}
 		retErr = fmt.Errorf("failed to check if controller should reconcile: %w", err)
 		return result, retErr
 	}
 
 	if !run {
-		log.Info("component version already reconciled", "version", componentVersion.Status.ReconciledVersion)
+		log.Info("no reconciling needed, requeuing", "component-version", componentVersion.Status.ReconciledVersion)
 		result, retErr = ctrl.Result{RequeueAfter: obj.GetRequeueAfter()}, nil
 		return result, retErr
 	}
@@ -199,21 +194,42 @@ func (r *LocalizationReconciler) shouldReconcile(ctx context.Context, cv *v1alph
 
 	// if source is a snapshot, check on its status
 	if obj.Spec.Source.SourceRef != nil {
-		switch obj.Spec.Source.SourceRef.Kind {
-		case "Snapshot":
-			snapshot := &v1alpha1.Snapshot{}
-			if err := r.Get(ctx, types.NamespacedName{
-				Namespace: obj.Spec.Source.SourceRef.Namespace,
-				Name:      obj.Spec.Source.SourceRef.Name,
-			}, snapshot); err != nil {
-				return false, err
+		d, err := r.getDigestFromSource(ctx, obj.Spec.Source.SourceRef)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
 			}
+			return false, err
+		}
 
-			if obj.Status.LastAppliedSourceDigest != snapshot.Status.LastReconciledDigest || obj.Status.LastAppliedSourceTag != snapshot.Status.LastReconciledTag {
-				return true, nil
-			}
-		default:
-			return false, errors.New(fmt.Sprintf("kind not supported for source object: %s", obj.Spec.Source.SourceRef.Kind))
+		if obj.Status.LastAppliedSourceDigest != d {
+			return true, nil
+		}
+	}
+
+	if obj.Spec.ConfigRef != nil && obj.Spec.ConfigRef.Resource.SourceRef != nil {
+		d, err := r.getDigestFromSource(ctx, obj.Spec.ConfigRef.Resource.SourceRef)
+		if err != nil {
+			return false, err
+		}
+
+		if obj.Status.LastAppliedConfigSourceDigest != d {
+			return true, nil
+		}
+	}
+
+	if obj.Spec.PatchStrategicMerge != nil {
+		d, err := r.getDigestFromSource(ctx, &meta.NamespacedObjectKindReference{
+			Kind:      obj.Spec.PatchStrategicMerge.Source.SourceRef.Kind,
+			Name:      obj.Spec.PatchStrategicMerge.Source.SourceRef.Name,
+			Namespace: obj.Spec.PatchStrategicMerge.Source.SourceRef.Namespace,
+		})
+		if err != nil {
+			return false, err
+		}
+
+		if obj.Status.LastAppliedPatchMergeSourceDigest != d {
+			return true, nil
 		}
 	}
 
@@ -264,29 +280,82 @@ func (r *LocalizationReconciler) reconcile(ctx context.Context, cv *v1alpha1.Com
 	obj.Status.LastAppliedComponentVersion = cv.Status.ReconciledVersion
 
 	if obj.Spec.Source.SourceRef != nil {
-		// For now, we only support setting last digest from Snapshot type source objects.
-		switch obj.Spec.Source.SourceRef.Kind {
-		case "Snapshot":
-			snapshot := &v1alpha1.Snapshot{}
-			if err := r.Get(ctx, types.NamespacedName{
-				Namespace: obj.Spec.Source.SourceRef.Namespace,
-				Name:      obj.Spec.Source.SourceRef.Name,
-			}, snapshot); err != nil {
-				return ctrl.Result{RequeueAfter: obj.GetRequeueAfter()}, err
-			}
-
-			obj.Status.LastAppliedSourceDigest = snapshot.Status.LastReconciledDigest
-			obj.Status.LastAppliedSourceTag = snapshot.Status.LastReconciledTag
-		default:
-			return ctrl.Result{}, fmt.Errorf("kind not supported for source object: %s", obj.Spec.Source.SourceRef.Kind)
+		d, err := r.getDigestFromSource(ctx, obj.Spec.Source.SourceRef)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get digest from source: %w", err)
 		}
+		obj.Status.LastAppliedSourceDigest = d
 	}
+	if obj.Spec.ConfigRef != nil && obj.Spec.ConfigRef.Resource.SourceRef != nil {
+		d, err := r.getDigestFromSource(ctx, obj.Spec.ConfigRef.Resource.SourceRef)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get digest from config source: %w", err)
+		}
+		obj.Status.LastAppliedConfigSourceDigest = d
+	}
+	if obj.Spec.PatchStrategicMerge != nil {
+		d, err := r.getDigestFromSource(ctx, &meta.NamespacedObjectKindReference{
+			Kind:      obj.Spec.PatchStrategicMerge.Source.SourceRef.Kind,
+			Name:      obj.Spec.PatchStrategicMerge.Source.SourceRef.Name,
+			Namespace: obj.Spec.PatchStrategicMerge.Source.SourceRef.Namespace,
+		})
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get digest from patch merge source: %w", err)
+		}
+		obj.Status.LastAppliedPatchMergeSourceDigest = d
+	}
+
 	// Remove any stale Ready condition, most likely False, set above. Its value
 	// is derived from the overall result of the reconciliation in the deferred
 	// block at the very end.
 	conditions.Delete(obj, meta.ReadyCondition)
 
 	return ctrl.Result{RequeueAfter: obj.GetRequeueAfter()}, nil
+}
+
+func (r *LocalizationReconciler) getDigestFromSource(ctx context.Context, sourceRef *meta.NamespacedObjectKindReference) (string, error) {
+	switch sourceRef.Kind {
+	case "Snapshot":
+		snapshot := &v1alpha1.Snapshot{}
+		if err := r.Get(ctx, types.NamespacedName{
+			Namespace: sourceRef.Namespace,
+			Name:      sourceRef.Name,
+		}, snapshot); err != nil {
+			return "", err
+		}
+
+		return snapshot.Status.LastReconciledDigest, nil
+	case "OCIRepository", "GitRepository", "Bucket":
+		return r.getArtifactChecksum(ctx, sourceRef)
+	default:
+		return "", fmt.Errorf("kind not supported for source object: %s", sourceRef.Kind)
+	}
+}
+
+func (r *LocalizationReconciler) getArtifactChecksum(ctx context.Context, sourceRef *meta.NamespacedObjectKindReference) (string, error) {
+	var source client.Object
+
+	switch sourceRef.Kind {
+	case v1beta2.OCIRepositoryKind:
+		source = &v1beta2.OCIRepository{}
+	case v1beta2.GitRepositoryKind:
+		source = &v1beta2.GitRepository{}
+	case v1beta2.BucketKind:
+		source = &v1beta2.Bucket{}
+	}
+	if err := r.Get(ctx, types.NamespacedName{
+		Namespace: sourceRef.Namespace,
+		Name:      sourceRef.Name,
+	}, source); err != nil {
+		return "", err
+	}
+
+	obj, ok := source.(v1beta2.Source)
+	if !ok {
+		return "", fmt.Errorf("not a source: %v", obj)
+	}
+
+	return obj.GetArtifact().Checksum, nil
 }
 
 func (r *LocalizationReconciler) requestsForRevisionChangeOf(indexKey string) func(obj client.Object) []reconcile.Request {

--- a/controllers/localization_controller_test.go
+++ b/controllers/localization_controller_test.go
@@ -836,7 +836,6 @@ func TestLocalizationShouldReconcile(t *testing.T) {
 				localization := DefaultLocalization.DeepCopy()
 				localization.Status.LastAppliedComponentVersion = "v0.0.1"
 				localization.Status.LastAppliedSourceDigest = "last-reconciled-digest"
-				localization.Status.LastAppliedSourceTag = "latest"
 				localization.Spec.Source.SourceRef = &meta.NamespacedObjectKindReference{
 					Kind:      "Snapshot",
 					Name:      "source-snapshot",

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -33,10 +33,12 @@ type testEnv struct {
 // defaults.
 type FakeKubeClientOption func(testEnv *testEnv)
 
-// WithScheme provides an option to set the scheme.
-func WithScheme(scheme *runtime.Scheme) FakeKubeClientOption {
+// WithAddToScheme adds the scheme
+func WithAddToScheme(addToScheme func(s *runtime.Scheme) error) FakeKubeClientOption {
 	return func(testEnv *testEnv) {
-		testEnv.scheme = scheme
+		if err := addToScheme(testEnv.scheme); err != nil {
+			panic(err)
+		}
 	}
 }
 

--- a/pkg/ocm/setup_test.go
+++ b/pkg/ocm/setup_test.go
@@ -55,10 +55,12 @@ type testEnv struct {
 // defaults.
 type FakeKubeClientOption func(testEnv *testEnv)
 
-// WithScheme provides an option to set the scheme.
-func WithScheme(scheme *runtime.Scheme) FakeKubeClientOption {
+// WithAddToScheme provides an option to set the scheme.
+func WithAddToScheme(addToScheme func(s *runtime.Scheme) error) FakeKubeClientOption {
 	return func(testEnv *testEnv) {
-		testEnv.scheme = scheme
+		if err := addToScheme(testEnv.scheme); err != nil {
+			panic(err)
+		}
 	}
 }
 


### PR DESCRIPTION
Extend `shouldReconcile` for `Configuration` and `Localization` to include checking the source Snapshot and Configuration object for changes.