### PR TITLE
Add events to `ocm-controller`

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   - services
   verbs:

--- a/controllers/componentversion_contoller_test.go
+++ b/controllers/componentversion_contoller_test.go
@@ -7,6 +7,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/fluxcd/pkg/apis/meta"
@@ -16,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
@@ -75,11 +77,16 @@ func TestComponentVersionReconcile(t *testing.T) {
 	fakeOcm.GetComponentVersionReturnsForName(root.descriptor.ComponentSpec.Name, root, nil)
 	fakeOcm.VerifyComponentReturns(true, nil)
 	fakeOcm.GetLatestComponentVersionReturns("v0.0.1", nil)
+	recorder := &record.FakeRecorder{
+		Events:        make(chan string, 32),
+		IncludeObject: true,
+	}
 
 	cvr := ComponentVersionReconciler{
-		Scheme:    env.scheme,
-		Client:    client,
-		OCMClient: fakeOcm,
+		Scheme:        env.scheme,
+		Client:        client,
+		EventRecorder: recorder,
+		OCMClient:     fakeOcm,
 	}
 	_, err := cvr.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{
@@ -99,17 +106,33 @@ func TestComponentVersionReconcile(t *testing.T) {
 	assert.Len(t, cv.Status.ComponentDescriptor.References, 1)
 	assert.Equal(t, "test-ref-1", cv.Status.ComponentDescriptor.References[0].Name)
 	assert.True(t, conditions.IsTrue(cv, meta.ReadyCondition))
+
+	close(recorder.Events)
+	event := ""
+	for e := range recorder.Events {
+		if strings.Contains(e, "Reconciliation finished, next run in") {
+			event = e
+			break
+		}
+	}
+	assert.Contains(t, event, "Reconciliation finished, next run in")
+	assert.Contains(t, event, "kind=ComponentVersion")
 }
 
 func TestComponentVersionReconcileFailure(t *testing.T) {
 	cv := DefaultComponent.DeepCopy()
 	client := env.FakeKubeClient(WithObjets(cv))
+	recorder := &record.FakeRecorder{
+		Events:        make(chan string, 32),
+		IncludeObject: true,
+	}
 
 	fakeOcm := &fakes.MockFetcher{}
 	cvr := ComponentVersionReconciler{
-		Scheme:    env.scheme,
-		Client:    client,
-		OCMClient: fakeOcm,
+		Scheme:        env.scheme,
+		Client:        client,
+		EventRecorder: recorder,
+		OCMClient:     fakeOcm,
 	}
 	_, err := cvr.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{
@@ -128,6 +151,18 @@ func TestComponentVersionReconcileFailure(t *testing.T) {
 
 	assert.True(t, conditions.IsFalse(cv, meta.ReadyCondition))
 	assert.True(t, conditions.IsTrue(cv, meta.StalledCondition))
+
+	close(recorder.Events)
+	found, event := false, ""
+	for e := range recorder.Events {
+		if strings.Contains(e, "failed to check version") {
+			found, event = true, e
+			break
+		}
+	}
+	assert.True(t, found)
+	assert.Contains(t, event, "failed to check version: failed to parse latest version: Invalid Semantic Version")
+	assert.Contains(t, event, "kind=ComponentVersion")
 }
 
 func TestComponentVersionSemverCheck(t *testing.T) {
@@ -136,15 +171,19 @@ func TestComponentVersionSemverCheck(t *testing.T) {
 		givenVersion      string
 		latestVersion     string
 		reconciledVersion string
+		isLatest          bool
+		constraintFailed  bool
 		expectedUpdate    bool
 		expectedErr       string
 	}{
 		{
-			description:       "current reconciled version satisfies given semver constraint",
+			description:       "current reconciled version is latest and satisfies given semver constraint",
 			givenVersion:      ">=0.0.2",
 			reconciledVersion: "0.0.3",
+			isLatest:          true,
+			constraintFailed:  false,
 			expectedUpdate:    false,
-			latestVersion:     "0.0.1",
+			latestVersion:     "0.0.3",
 		},
 		{
 			description:       "given version requires component update",
@@ -155,9 +194,11 @@ func TestComponentVersionSemverCheck(t *testing.T) {
 		},
 		{
 			description:       "latest available version does not satisfy given semver constraint",
-			givenVersion:      "=0.0.2",
+			givenVersion:      "=0.0.3",
 			reconciledVersion: "0.0.1",
-			latestVersion:     "0.0.1",
+			latestVersion:     "0.0.2",
+			isLatest:          false,
+			constraintFailed:  true,
 			expectedUpdate:    false,
 		},
 	}
@@ -169,20 +210,31 @@ func TestComponentVersionSemverCheck(t *testing.T) {
 			fakeClient := env.FakeKubeClient(WithObjets(obj))
 			fakeOcm := &fakes.MockFetcher{}
 			fakeOcm.GetLatestComponentVersionReturns(tt.latestVersion, nil)
+			recorder := &record.FakeRecorder{
+				Events: make(chan string, 32),
+			}
+
 			cvr := ComponentVersionReconciler{
-				Scheme:    env.scheme,
-				Client:    fakeClient,
-				OCMClient: fakeOcm,
+				Scheme:        env.scheme,
+				Client:        fakeClient,
+				EventRecorder: recorder,
+				OCMClient:     fakeOcm,
 			}
 			update, _, err := cvr.checkVersion(context.Background(), obj)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedUpdate, update)
+
+			close(recorder.Events)
+			for e := range recorder.Events {
+				switch {
+				case tt.expectedUpdate:
+					assert.Contains(t, e, "Version check succeeded, found latest")
+				case tt.constraintFailed:
+					assert.Contains(t, e, "Version constraint check failed, continuing without update")
+				}
+			}
 		})
 	}
-}
-
-func TestComponentVersionEvent(t *testing.T) {
-
 }
 
 type mockComponent struct {

--- a/controllers/componentversion_contoller_test.go
+++ b/controllers/componentversion_contoller_test.go
@@ -181,6 +181,10 @@ func TestComponentVersionSemverCheck(t *testing.T) {
 	}
 }
 
+func TestComponentVersionEvent(t *testing.T) {
+
+}
+
 type mockComponent struct {
 	descriptor *ocmdesc.ComponentDescriptor
 	ocm.ComponentVersionAccess

--- a/controllers/componentversion_controller.go
+++ b/controllers/componentversion_controller.go
@@ -176,9 +176,9 @@ func (r *ComponentVersionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err != nil {
 		log.Error(err, "failed to verify component", "component", klog.KObj(obj))
 		err := fmt.Errorf("failed to verify component: %w", err)
-		event.New(r.EventRecorder, obj, eventv1.EventSeverityError, fmt.Sprintf("%s, retrying in %s", err.Error(), obj.GetRequeueAfter()), nil)
 		conditions.MarkStalled(obj, v1alpha1.VerificationFailedReason, err.Error())
 		conditions.MarkFalse(obj, meta.ReadyCondition, v1alpha1.VerificationFailedReason, err.Error())
+		event.New(r.EventRecorder, obj, eventv1.EventSeverityError, fmt.Sprintf("%s, retrying in %s", err.Error(), obj.GetRequeueAfter()), nil)
 		result, retErr = ctrl.Result{}, nil
 		return result, retErr
 	}
@@ -186,9 +186,9 @@ func (r *ComponentVersionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if !ok {
 		err := fmt.Errorf("attempted to verify component, but the digest didn't match")
 		log.Error(err, "invalid digest for component version", "component", klog.KObj(obj))
-		event.New(r.EventRecorder, obj, eventv1.EventSeverityError, fmt.Sprintf("%s, retrying in %s", err.Error(), obj.GetRequeueAfter()), nil)
 		conditions.MarkStalled(obj, v1alpha1.VerificationFailedReason, err.Error())
 		conditions.MarkFalse(obj, meta.ReadyCondition, v1alpha1.VerificationFailedReason, err.Error())
+		event.New(r.EventRecorder, obj, eventv1.EventSeverityError, fmt.Sprintf("%s, retrying in %s", err.Error(), obj.GetRequeueAfter()), nil)
 		result, retErr = ctrl.Result{}, nil
 		return result, retErr
 	}
@@ -269,6 +269,7 @@ func (r *ComponentVersionReconciler) reconcile(ctx context.Context, obj *v1alpha
 		err = fmt.Errorf("failed to get component version: %w", err)
 		conditions.MarkStalled(obj, v1alpha1.ComponentVersionInvalidReason, err.Error())
 		conditions.MarkFalse(obj, meta.ReadyCondition, v1alpha1.ComponentVersionInvalidReason, err.Error())
+		event.New(r.EventRecorder, obj, eventv1.EventSeverityError, err.Error(), nil)
 		return ctrl.Result{}, err
 	}
 
@@ -320,6 +321,7 @@ func (r *ComponentVersionReconciler) reconcile(ctx context.Context, obj *v1alpha
 	if err != nil {
 		err = fmt.Errorf("failed to create or update component descriptor: %w", err)
 		conditions.MarkFalse(obj, meta.ReadyCondition, v1alpha1.CreateOrUpdateComponentDescriptorFailedReason, err.Error())
+		event.New(r.EventRecorder, obj, eventv1.EventSeverityError, err.Error(), nil)
 		return ctrl.Result{}, err
 	}
 
@@ -337,6 +339,7 @@ func (r *ComponentVersionReconciler) reconcile(ctx context.Context, obj *v1alpha
 		if err != nil {
 			err = fmt.Errorf("failed to parse references: %w", err)
 			conditions.MarkFalse(obj, meta.ReadyCondition, v1alpha1.ParseReferencesFailedReason, err.Error())
+			event.New(r.EventRecorder, obj, eventv1.EventSeverityError, err.Error(), nil)
 			return ctrl.Result{}, err
 		}
 	}

--- a/controllers/componentversion_controller.go
+++ b/controllers/componentversion_controller.go
@@ -18,6 +18,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	kuberecorder "k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -39,6 +40,7 @@ import (
 type ComponentVersionReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+	kuberecorder.EventRecorder
 
 	OCMClient ocmclient.FetchVerifier
 }

--- a/controllers/componentversion_controller.go
+++ b/controllers/componentversion_controller.go
@@ -52,6 +52,7 @@ type ComponentVersionReconciler struct {
 //+kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;create;update;patch;delete
 
 // +kubebuilder:rbac:groups="",resources=secrets;serviceaccounts,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ComponentVersionReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -26,12 +26,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/runtime/conditions"
 	rreconcile "github.com/fluxcd/pkg/runtime/reconcile"
 	"github.com/open-component-model/ocm-controller/api/v1alpha1"
 	deliveryv1alpha1 "github.com/open-component-model/ocm-controller/api/v1alpha1"
 	"github.com/open-component-model/ocm-controller/pkg/cache"
+	"github.com/open-component-model/ocm-controller/pkg/event"
 	"github.com/open-component-model/ocm-controller/pkg/ocm"
 )
 
@@ -142,6 +144,7 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			// Set the return err as the ready failure message is the resource is not ready, but also not reconciling or stalled.
 			if ready := conditions.Get(obj, meta.ReadyCondition); ready != nil && ready.Status == metav1.ConditionFalse && !conditions.IsStalled(obj) {
 				retErr = errors.New(conditions.GetMessage(obj, meta.ReadyCondition))
+				event.New(r.EventRecorder, obj, eventv1.EventSeverityError, err.Error(), nil)
 			}
 		}
 
@@ -157,11 +160,14 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if !conditions.IsReconciling(obj) && !conditions.IsStalled(obj) &&
 			retErr == nil && result.RequeueAfter == obj.GetRequeueAfter() {
 			conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, "Reconciliation success")
+			event.New(r.EventRecorder, obj, eventv1.EventSeverityInfo, "Reconciliation succeeded", nil)
 		}
 
 		// Set status observed generation option if the object is stalled or ready.
 		if conditions.IsStalled(obj) || conditions.IsReady(obj) {
 			obj.Status.ObservedGeneration = obj.Generation
+			event.New(r.EventRecorder, obj, eventv1.EventSeverityInfo, fmt.Sprintf("Reconciliation finished, next run in %s", obj.GetRequeueAfter()),
+				map[string]string{v1alpha1.GroupVersion.Group + "/configuration/snapshot_digest": obj.Status.LatestSnapshotDigest})
 		}
 
 		if err := patchHelper.Patch(ctx, obj); err != nil {

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	kuberecorder "k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -37,7 +38,8 @@ import (
 // ConfigurationReconciler reconciles a Configuration object
 type ConfigurationReconciler struct {
 	client.Client
-	Scheme            *runtime.Scheme
+	Scheme *runtime.Scheme
+	kuberecorder.EventRecorder
 	ReconcileInterval time.Duration
 	RetryInterval     time.Duration
 	Cache             cache.Cache

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -51,6 +51,7 @@ type ConfigurationReconciler struct {
 //+kubebuilder:rbac:groups=delivery.ocm.software,resources=configurations/finalizers,verbs=update
 
 //+kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=gitrepositories;buckets;ocirepositories,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ConfigurationReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/controllers/localization_controller.go
+++ b/controllers/localization_controller.go
@@ -51,6 +51,8 @@ type LocalizationReconciler struct {
 //+kubebuilder:rbac:groups=delivery.ocm.software,resources=localizations/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=delivery.ocm.software,resources=localizations/finalizers,verbs=update
 
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *LocalizationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	snapshotSourceKey := ".metadata.snapshot.source"

--- a/controllers/localization_controller.go
+++ b/controllers/localization_controller.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	kuberecorder "k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,7 +39,8 @@ import (
 // LocalizationReconciler reconciles a Localization object
 type LocalizationReconciler struct {
 	client.Client
-	Scheme            *runtime.Scheme
+	Scheme *runtime.Scheme
+	kuberecorder.EventRecorder
 	ReconcileInterval time.Duration
 	RetryInterval     time.Duration
 	OCMClient         ocm.FetchVerifier

--- a/controllers/localization_controller.go
+++ b/controllers/localization_controller.go
@@ -28,11 +28,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/runtime/conditions"
 	rreconcile "github.com/fluxcd/pkg/runtime/reconcile"
 	"github.com/open-component-model/ocm-controller/api/v1alpha1"
 	"github.com/open-component-model/ocm-controller/pkg/cache"
+	"github.com/open-component-model/ocm-controller/pkg/event"
 	"github.com/open-component-model/ocm-controller/pkg/ocm"
 )
 
@@ -144,6 +146,7 @@ func (r *LocalizationReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			// Set the return err as the ready failure message is the resource is not ready, but also not reconciling or stalled.
 			if ready := conditions.Get(obj, meta.ReadyCondition); ready != nil && ready.Status == metav1.ConditionFalse && !conditions.IsStalled(obj) {
 				retErr = errors.New(conditions.GetMessage(obj, meta.ReadyCondition))
+				event.New(r.EventRecorder, obj, eventv1.EventSeverityError, retErr.Error(), nil)
 			}
 		}
 
@@ -159,11 +162,14 @@ func (r *LocalizationReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if !conditions.IsReconciling(obj) && !conditions.IsStalled(obj) &&
 			retErr == nil && result.RequeueAfter == obj.GetRequeueAfter() {
 			conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, "Reconciliation success")
+			event.New(r.EventRecorder, obj, eventv1.EventSeverityInfo, "Reconciliation succeeded", nil)
 		}
 
 		// Set status observed generation option if the object is stalled or ready.
 		if conditions.IsStalled(obj) || conditions.IsReady(obj) {
 			obj.Status.ObservedGeneration = obj.Generation
+			event.New(r.EventRecorder, obj, eventv1.EventSeverityInfo, fmt.Sprintf("Reconciliation finished, next run in %s", obj.GetRequeueAfter()),
+				map[string]string{v1alpha1.GroupVersion.Group + "/localization/snapshot_digest": obj.Status.LatestSnapshotDigest})
 		}
 
 		if err := patchHelper.Patch(ctx, obj); err != nil {
@@ -275,6 +281,7 @@ func (r *LocalizationReconciler) reconcile(ctx context.Context, cv *v1alpha1.Com
 		}
 		err = fmt.Errorf("failed to reconcile mutation object: %w", err)
 		conditions.MarkFalse(obj, meta.ReadyCondition, v1alpha1.ReconcileMuationObjectFailedReason, err.Error())
+		event.New(r.EventRecorder, obj, eventv1.EventSeverityError, err.Error(), nil)
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/resource_controller.go
+++ b/controllers/resource_controller.go
@@ -23,12 +23,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/runtime/conditions"
 	rreconcile "github.com/fluxcd/pkg/runtime/reconcile"
 	"github.com/open-component-model/ocm-controller/api/v1alpha1"
 	"github.com/open-component-model/ocm-controller/pkg/cache"
 	"github.com/open-component-model/ocm-controller/pkg/component"
+	"github.com/open-component-model/ocm-controller/pkg/event"
 	"github.com/open-component-model/ocm-controller/pkg/ocm"
 )
 
@@ -85,6 +87,7 @@ func (r *ResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		err = fmt.Errorf("failed to get component version: %w", err)
 		conditions.MarkStalled(obj, v1alpha1.ComponentVersionInvalidReason, err.Error())
 		conditions.MarkFalse(obj, meta.ReadyCondition, v1alpha1.ComponentVersionInvalidReason, err.Error())
+		event.New(r.EventRecorder, obj, eventv1.EventSeverityError, err.Error(), nil)
 		result, retErr = ctrl.Result{}, nil
 		return result, retErr
 	}
@@ -142,11 +145,14 @@ func (r *ResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		if !conditions.IsReconciling(obj) && !conditions.IsStalled(obj) &&
 			retErr == nil && result.RequeueAfter == obj.GetRequeueAfter() {
 			conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, "Reconciliation success")
+			event.New(r.EventRecorder, obj, eventv1.EventSeverityInfo, "Reconciliation success", nil)
 		}
 
 		// Set status observed generation option if the object is stalled or ready.
 		if conditions.IsStalled(obj) || conditions.IsReady(obj) {
 			obj.Status.ObservedGeneration = obj.Generation
+			event.New(r.EventRecorder, obj, eventv1.EventSeverityInfo, fmt.Sprintf("Reconciliation finished, next run in %s", obj.GetRequeueAfter()),
+				map[string]string{v1alpha1.GroupVersion.Group + "/resource": obj.Status.LastAppliedResourceVersion})
 		}
 
 		if err := patchHelper.Patch(ctx, obj); err != nil {
@@ -206,6 +212,7 @@ func (r *ResourceReconciler) reconcile(ctx context.Context, componentVersion *v1
 	if err != nil {
 		err = fmt.Errorf("failed to get resource: %w", err)
 		conditions.MarkFalse(obj, meta.ReadyCondition, v1alpha1.GetResourceFailedReason, err.Error())
+		event.New(r.EventRecorder, obj, eventv1.EventSeverityError, err.Error(), nil)
 		return ctrl.Result{}, err
 	}
 	defer reader.Close()
@@ -221,6 +228,7 @@ func (r *ResourceReconciler) reconcile(ctx context.Context, componentVersion *v1
 	if err != nil {
 		err = fmt.Errorf("failed to get component descriptor for resource: %w", err)
 		conditions.MarkFalse(obj, meta.ReadyCondition, v1alpha1.GetComponentDescriptorFailedReason, err.Error())
+		event.New(r.EventRecorder, obj, eventv1.EventSeverityError, err.Error(), nil)
 		return ctrl.Result{}, err
 	}
 
@@ -229,6 +237,7 @@ func (r *ResourceReconciler) reconcile(ctx context.Context, componentVersion *v1
 		conditions.MarkFalse(obj, meta.ReadyCondition, v1alpha1.ComponentDescriptorNotFoundReason, err.Error())
 		// Mark stalled because we can't do anything until the component descriptor is available. Likely requires some sort of manual intervention.
 		conditions.MarkStalled(obj, v1alpha1.ComponentDescriptorNotFoundReason, err.Error())
+		event.New(r.EventRecorder, obj, eventv1.EventSeverityError, err.Error(), nil)
 		return ctrl.Result{}, err
 	}
 
@@ -269,6 +278,7 @@ func (r *ResourceReconciler) reconcile(ctx context.Context, componentVersion *v1
 	if err != nil {
 		err = fmt.Errorf("failed to create or update snapshot: %w", err)
 		conditions.MarkFalse(obj, meta.ReadyCondition, v1alpha1.CreateOrUpdateSnapshotFailedReason, err.Error())
+		event.New(r.EventRecorder, obj, eventv1.EventSeverityError, err.Error(), nil)
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/resource_controller.go
+++ b/controllers/resource_controller.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	kuberecorder "k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,7 +35,8 @@ import (
 // ResourceReconciler reconciles a Resource object
 type ResourceReconciler struct {
 	client.Client
-	Scheme    *runtime.Scheme
+	Scheme *runtime.Scheme
+	kuberecorder.EventRecorder
 	OCMClient ocm.FetchVerifier
 	Cache     cache.Cache
 }

--- a/controllers/resource_controller.go
+++ b/controllers/resource_controller.go
@@ -41,9 +41,11 @@ type ResourceReconciler struct {
 	Cache     cache.Cache
 }
 
-//+kubebuilder:rbac:groups=delivery.ocm.software,resources=resources,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=delivery.ocm.software,resources=resources/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=delivery.ocm.software,resources=resources/finalizers,verbs=update
+// +kubebuilder:rbac:groups=delivery.ocm.software,resources=resources,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=delivery.ocm.software,resources=resources/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=delivery.ocm.software,resources=resources/finalizers,verbs=update
+
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ResourceReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/controllers/snapshot_controller.go
+++ b/controllers/snapshot_controller.go
@@ -53,6 +53,7 @@ type SnapshotReconciler struct {
 //+kubebuilder:rbac:groups=delivery.ocm.software,resources=snapshots/finalizers,verbs=update
 
 // +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=ocirepositories,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SnapshotReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/controllers/snapshot_controller.go
+++ b/controllers/snapshot_controller.go
@@ -20,6 +20,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	kuberecorder "k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -40,7 +41,8 @@ const (
 // SnapshotReconciler reconciles a Snapshot object
 type SnapshotReconciler struct {
 	client.Client
-	Scheme              *runtime.Scheme
+	Scheme *runtime.Scheme
+	kuberecorder.EventRecorder
 	RegistryServiceName string
 
 	Cache cache.Cache

--- a/controllers/snapshot_controller.go
+++ b/controllers/snapshot_controller.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"time"
 
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/runtime/conditions"
 	"github.com/fluxcd/pkg/runtime/patch"
@@ -31,6 +32,7 @@ import (
 
 	"github.com/open-component-model/ocm-controller/api/v1alpha1"
 	deliveryv1alpha1 "github.com/open-component-model/ocm-controller/api/v1alpha1"
+	"github.com/open-component-model/ocm-controller/pkg/event"
 	"github.com/open-component-model/ocm-controller/pkg/ocm"
 )
 
@@ -110,6 +112,8 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// Set status observed generation option if the object is stalled or ready.
 		if conditions.IsStalled(obj) || conditions.IsReady(obj) {
 			obj.Status.ObservedGeneration = obj.Generation
+			event.New(r.EventRecorder, obj, eventv1.EventSeverityInfo, "Reconciliation finished",
+				map[string]string{v1alpha1.GroupVersion.Group + "/snapshot/digest": obj.Status.LastReconciledDigest})
 		}
 
 		if err := patchHelper.Patch(ctx, obj); err != nil {
@@ -120,6 +124,7 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	name, err := ocm.ConstructRepositoryName(obj.Spec.Identity)
 	if err != nil {
 		conditions.MarkFalse(obj, meta.ReadyCondition, v1alpha1.CreateRepositoryNameReason, err.Error())
+		event.New(r.EventRecorder, obj, eventv1.EventSeverityError, err.Error(), nil)
 		return ctrl.Result{}, fmt.Errorf("failed to construct name: %w", err)
 	}
 
@@ -150,9 +155,11 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return nil
 		})
 		if err != nil {
-			log.Error(err, "failed to create or update oci repository")
+			msg := "failed to create or update oci repository"
+			log.Error(err, msg)
 			conditions.MarkFalse(obj, meta.ReadyCondition, v1alpha1.CreateOrUpdateOCIRepositoryFailedReason, err.Error())
 			conditions.MarkStalled(obj, v1alpha1.CreateOrUpdateOCIRepositoryFailedReason, err.Error())
+			event.New(r.EventRecorder, obj, eventv1.EventSeverityError, msg, nil)
 			retErr = nil
 			return ctrl.Result{}, nil
 		}
@@ -161,7 +168,9 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	obj.Status.LastReconciledDigest = obj.Spec.Digest
 	obj.Status.LastReconciledTag = obj.Spec.Tag
 	obj.Status.RepositoryURL = fmt.Sprintf("http://%s/%s", r.RegistryServiceName, name)
-	conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, "Snapshot with name '%s' is ready", obj.Name)
+	msg := fmt.Sprintf("Snapshot with name '%s' is ready", obj.Name)
+	conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, msg)
+	event.New(r.EventRecorder, obj, eventv1.EventSeverityInfo, msg, nil)
 	log.Info("snapshot successfully reconciled", "snapshot", klog.KObj(obj))
 
 	return ctrl.Result{}, nil

--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,7 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fluxcd/pkg/apis/acl v0.1.0 // indirect
+	github.com/fluxcd/pkg/apis/event v0.3.0 // indirect
 	github.com/fluxcd/pkg/apis/kustomize v0.8.0 // indirect
 	github.com/fvbommel/sortorder v1.0.2 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/containers/image/v5 v5.21.1
 	github.com/cyphar/filepath-securejoin v0.2.3
 	github.com/distribution/distribution/v3 v3.0.0-20220907155224-78b9c98c5c31
+	github.com/fluxcd/pkg/apis/event v0.3.0
 	github.com/fluxcd/pkg/apis/meta v0.19.0
 	github.com/fluxcd/pkg/http/fetch v0.3.0
 	github.com/fluxcd/pkg/kustomize v0.13.0
@@ -87,7 +88,6 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fluxcd/pkg/apis/acl v0.1.0 // indirect
-	github.com/fluxcd/pkg/apis/event v0.3.0 // indirect
 	github.com/fluxcd/pkg/apis/kustomize v0.8.0 // indirect
 	github.com/fvbommel/sortorder v1.0.2 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -460,6 +460,8 @@ github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
 github.com/fluxcd/pkg/apis/acl v0.1.0 h1:EoAl377hDQYL3WqanWCdifauXqXbMyFuK82NnX6pH4Q=
 github.com/fluxcd/pkg/apis/acl v0.1.0/go.mod h1:zfEZzz169Oap034EsDhmCAGgnWlcWmIObZjYMusoXS8=
+github.com/fluxcd/pkg/apis/event v0.3.0 h1:B+IXmfSniUGfoczheNAH0YULgS+ejxMl58RyWlvLa1c=
+github.com/fluxcd/pkg/apis/event v0.3.0/go.mod h1:xYOOlf+9gCBSYcs93N2XAbJvSVwuVBDBUzqhR+cAo7M=
 github.com/fluxcd/pkg/apis/kustomize v0.8.0 h1:A6aLolxPV2Sll44SOHiX96lbXXmRZmS5BoEerkRHrfM=
 github.com/fluxcd/pkg/apis/kustomize v0.8.0/go.mod h1:9DPEVSfVIkiC2H3Dk6Ght4YJkswhYIaufXla4tB5Y84=
 github.com/fluxcd/pkg/apis/meta v0.19.0 h1:CX75e/eaRWZDTzNdMSWomY1InlssLKcS8GQDSg/aopI=

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -1,0 +1,29 @@
+package event
+
+import (
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	"github.com/fluxcd/pkg/apis/meta"
+	"github.com/fluxcd/pkg/runtime/conditions"
+
+	corev1 "k8s.io/api/core/v1"
+	kuberecorder "k8s.io/client-go/tools/record"
+)
+
+func New(recorder kuberecorder.EventRecorder, obj conditions.Getter, severity, msg string, metadata map[string]string) {
+
+	if metadata == nil {
+		metadata = map[string]string{}
+	}
+
+	reason := severity
+	if r := conditions.GetReason(obj, meta.ReadyCondition); r != "" {
+		reason = r
+	}
+
+	eventType := corev1.EventTypeNormal
+	if severity == eventv1.EventSeverityError {
+		eventType = corev1.EventTypeWarning
+	}
+
+	recorder.AnnotatedEventf(obj, metadata, eventType, reason, msg)
+}

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -10,7 +10,6 @@ import (
 )
 
 func New(recorder kuberecorder.EventRecorder, obj conditions.Getter, severity, msg string, metadata map[string]string) {
-
 	if metadata == nil {
 		metadata = map[string]string{}
 	}

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -1,0 +1,50 @@
+package event
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/open-component-model/ocm-controller/api/v1alpha1"
+
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	"github.com/fluxcd/pkg/apis/meta"
+
+	"github.com/fluxcd/pkg/runtime/conditions"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/tools/record"
+)
+
+func TestNewEvent(t *testing.T) {
+	eventTests := []struct {
+		description string
+		severity    string
+		expected    string
+	}{
+		{
+			description: "event is of type info",
+			severity:    eventv1.EventSeverityInfo,
+			expected:    "Normal",
+		},
+		{
+			description: "event is of type error",
+			severity:    eventv1.EventSeverityError,
+			expected:    "Warning",
+		},
+	}
+	for i, tt := range eventTests {
+		t.Run(fmt.Sprintf("%d: %s", i, tt.description), func(t *testing.T) {
+			recorder := record.NewFakeRecorder(32)
+			obj := &v1alpha1.ComponentVersion{}
+			conditions.MarkStalled(obj, v1alpha1.CheckVersionFailedReason, "err")
+			conditions.MarkFalse(obj, meta.ReadyCondition, v1alpha1.CheckVersionFailedReason, "err")
+
+			New(recorder, obj, tt.severity, "msg", nil)
+
+			close(recorder.Events)
+			for e := range recorder.Events {
+				assert.Contains(t, e, "CheckVersionFailedReason")
+				assert.Contains(t, e, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #49 

This PR:
* Initialises the event recorder for the ocm-controller in `main.go` and for all reconcilers
* Adds RBAC to ClusterRole to create/patch events for all reconcilers of ocm-controller.
* Adds an `event()` method that emits an event, for example, when reconciliation succeeds or fails, with unit tests
* Adds events to Snapshot, Resource, Localization, and Configuration reconcilers

Reconciliation that finished successfully or is requeued, similar to the Flux one:
```
ocm-system   18s         Normal    Succeeded                    componentversion/podinfo               Reconciliation finished, next run in 10m0s
```

Reconciliation with an error:
```
ocm-system    6m3s        Warning   CheckVersionFailedReason   componentversion/podinfo                        Version constraint check failed, continuing without update
```