### PR TITLE
bug: fix version checking up to constraint

### DIFF
--- a/controllers/componentversion_contoller_test.go
+++ b/controllers/componentversion_contoller_test.go
@@ -141,7 +141,7 @@ func TestComponentVersionReconcileFailure(t *testing.T) {
 			Namespace: cv.Namespace,
 		},
 	})
-	assert.EqualError(t, err, "failed to check version: failed to parse reconciled version: Invalid Semantic Version")
+	assert.EqualError(t, err, "failed to check version: failed to parse latest version: Invalid Semantic Version")
 
 	t.Log("verifying updated object status")
 	err = client.Get(context.Background(), types.NamespacedName{
@@ -162,7 +162,7 @@ func TestComponentVersionReconcileFailure(t *testing.T) {
 		}
 	}
 	assert.True(t, found)
-	assert.Contains(t, event, "failed to check version: failed to parse reconciled version: Invalid Semantic Version")
+	assert.Contains(t, event, "failed to check version: failed to parse latest version: Invalid Semantic Version")
 	assert.Contains(t, event, "kind=ComponentVersion")
 }
 

--- a/controllers/componentversion_controller.go
+++ b/controllers/componentversion_controller.go
@@ -214,7 +214,7 @@ func (r *ComponentVersionReconciler) checkVersion(ctx context.Context, obj *v1al
 	if err != nil {
 		return false, "", fmt.Errorf("failed to get latest component version: %w", err)
 	}
-	log.V(4).Info("got newest version from component", "version", latest)
+	log.V(4).Info("got latest version of component", "version", latest)
 
 	latestSemver, err := semver.NewVersion(latest)
 	if err != nil {
@@ -232,7 +232,7 @@ func (r *ComponentVersionReconciler) checkVersion(ctx context.Context, obj *v1al
 	log.V(4).Info("current reconciled version is", "reconciled", current.String())
 
 	if latestSemver.Equal(current) || current.GreaterThan(latestSemver) {
-		log.V(4).Info("Latest reconciled version equal to or greater than newest version", "version", latestSemver)
+		log.V(4).Info("Reconciled version equal to or greater than newest available version", "version", latestSemver)
 		return false, "", nil
 	}
 

--- a/controllers/componentversion_controller.go
+++ b/controllers/componentversion_controller.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/runtime/conditions"
@@ -207,13 +207,6 @@ func (r *ComponentVersionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 func (r *ComponentVersionReconciler) checkVersion(ctx context.Context, obj *v1alpha1.ComponentVersion) (bool, string, error) {
 	log := log.FromContext(ctx).WithName("ocm-component-version-reconcile")
 
-	// get given semver constraint
-	constraint, err := semver.NewConstraint(obj.Spec.Version.Semver)
-	if err != nil {
-		return false, "", fmt.Errorf("failed to parse given semver constraint: %w", err)
-	}
-
-	// get current reconciled version
 	reconciledVersion := "0.0.0"
 	if obj.Status.ReconciledVersion != "" {
 		reconciledVersion = obj.Status.ReconciledVersion
@@ -224,8 +217,20 @@ func (r *ComponentVersionReconciler) checkVersion(ctx context.Context, obj *v1al
 	}
 	log.V(4).Info("current reconciled version is", "reconciled", current.String())
 
-	// get latest available component version
-	latest, err := r.OCMClient.GetLatestComponentVersion(ctx, obj)
+	// Check if the constraint can be parsed as a specific version. If yes, we just set that as version. This can then
+	// be used as a downgrade option.
+	if concrete, err := semver.NewVersion(obj.Spec.Version.Semver); err == nil {
+		if !concrete.Equal(current) {
+			return true, concrete.Original(), nil
+		}
+
+		return false, "", nil
+	}
+
+	// If not, we'll list all version UP-TO the constraint and use the max. But we will not update
+	// if the new version is below the current. This is to avoid forced downgrades if the
+	// remote deleted a version.
+	latest, err := r.OCMClient.GetLatestValidComponentVersion(ctx, obj)
 	if err != nil {
 		return false, "", fmt.Errorf("failed to get latest component version: %w", err)
 	}
@@ -236,16 +241,8 @@ func (r *ComponentVersionReconciler) checkVersion(ctx context.Context, obj *v1al
 		return false, "", fmt.Errorf("failed to parse latest version: %w", err)
 	}
 
-	if latestSemver.Equal(current) {
-		log.V(4).Info("Latest version already reconciled", "version", latestSemver)
-		return false, "", nil
-	}
-
-	// compare given constraint and latest available version
-	valid, errs := constraint.Validate(latestSemver)
-	if !valid || len(errs) > 0 {
-		log.Info("Version constraint check failed with the following problems", "errors", errs, "version", current)
-		event.New(r.EventRecorder, obj, eventv1.EventSeverityError, "Version constraint check failed, continuing without update", nil)
+	if latestSemver.Equal(current) || current.GreaterThan(latestSemver) {
+		log.V(4).Info("Latest reconciled version equal to or greater than newest version", "version", latestSemver)
 		return false, "", nil
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -151,7 +151,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect

--- a/pkg/ocm/fakes/fakes.go
+++ b/pkg/ocm/fakes/fakes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/go-logr/logr"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 
 	"github.com/open-component-model/ocm-controller/api/v1alpha1"
@@ -136,7 +137,7 @@ func (m *MockFetcher) GetLatestComponentVersionWasNotCalled() bool {
 	return len(m.getLatestComponentVersionCalledWith) == 0
 }
 
-func (m *MockFetcher) ListComponentVersions(ocmCtx ocm.Context, obj *v1alpha1.ComponentVersion) ([]ocmctrl.Version, error) {
+func (m *MockFetcher) ListComponentVersions(logger logr.Logger, octx ocm.Context, obj *v1alpha1.ComponentVersion) ([]ocmctrl.Version, error) {
 	m.listComponentVersionsCalledWith = append(m.listComponentVersionsCalledWith, []any{obj})
 	return m.listComponentVersionsVersions, m.listComponentVersionsErr
 }

--- a/pkg/ocm/fakes/fakes.go
+++ b/pkg/ocm/fakes/fakes.go
@@ -118,7 +118,7 @@ func (m *MockFetcher) VerifyComponentWasNotCalled() bool {
 	return len(m.verifyComponentCalledWith) == 0
 }
 
-func (m *MockFetcher) GetLatestComponentVersion(ctx context.Context, obj *v1alpha1.ComponentVersion) (string, error) {
+func (m *MockFetcher) GetLatestValidComponentVersion(ctx context.Context, obj *v1alpha1.ComponentVersion) (string, error) {
 	m.getComponentVersionCalledWith = append(m.getComponentVersionCalledWith, []any{obj})
 	return m.getLatestComponentVersionVersion, m.getLatestComponentVersionErr
 }

--- a/pkg/ocm/ocm_test.go
+++ b/pkg/ocm/ocm_test.go
@@ -125,37 +125,158 @@ func TestClient_GetComponentVersion(t *testing.T) {
 	assert.Equal(t, cv.Spec.Component, cva.GetName())
 }
 
-func TestClient_GetLatestComponentVersion(t *testing.T) {
-	fakeKubeClient := env.FakeKubeClient()
-	cache := oci.NewClient(strings.TrimPrefix(env.repositoryURL, "http://"))
-	ocmClient := NewClient(fakeKubeClient, cache)
-	component := "github.com/skarlso/ocm-demo-index"
-
-	err := env.AddComponentVersionToRepository(Component{
-		Name:    component,
-		Version: "v0.0.5",
-	})
-	require.NoError(t, err)
-
-	cv := &v1alpha1.ComponentVersion{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-name",
-			Namespace: "default",
+func TestClient_GetLatestValidComponentVersion(t *testing.T) {
+	testCases := []struct {
+		name             string
+		componentVersion func(name string) *v1alpha1.ComponentVersion
+		setupComponents  func(name string) error
+		expectedVersion  string
+	}{
+		{
+			name: "semver constraint works for greater versions",
+			componentVersion: func(name string) *v1alpha1.ComponentVersion {
+				return &v1alpha1.ComponentVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-name",
+						Namespace: "default",
+					},
+					Spec: v1alpha1.ComponentVersionSpec{
+						Component: name,
+						Version: v1alpha1.Version{
+							Semver: ">v0.0.1",
+						},
+						Repository: v1alpha1.Repository{
+							URL: env.repositoryURL,
+						},
+					},
+				}
+			},
+			setupComponents: func(name string) error {
+				for _, v := range []string{"v0.0.5"} {
+					if err := env.AddComponentVersionToRepository(Component{
+						Name:    name,
+						Version: v,
+					}); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			expectedVersion: "v0.0.5",
 		},
-		Spec: v1alpha1.ComponentVersionSpec{
-			Component: component,
-			Version: v1alpha1.Version{
-				Semver: ">v0.0.1",
+		{
+			name: "semver is a concrete match with multiple versions",
+			componentVersion: func(name string) *v1alpha1.ComponentVersion {
+				return &v1alpha1.ComponentVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-name",
+						Namespace: "default",
+					},
+					Spec: v1alpha1.ComponentVersionSpec{
+						Component: name,
+						Version: v1alpha1.Version{
+							Semver: "v0.0.1",
+						},
+						Repository: v1alpha1.Repository{
+							URL: env.repositoryURL,
+						},
+					},
+				}
 			},
-			Repository: v1alpha1.Repository{
-				URL: env.repositoryURL,
+			setupComponents: func(name string) error {
+				for _, v := range []string{"v0.0.1", "v0.0.2", "v0.0.3"} {
+					if err := env.AddComponentVersionToRepository(Component{
+						Name:    name,
+						Version: v,
+					}); err != nil {
+						return err
+					}
+				}
+				return nil
 			},
+			expectedVersion: "v0.0.1",
+		},
+		{
+			name: "semver is in between available versions should return the one that's still matching instead of the latest available",
+			componentVersion: func(name string) *v1alpha1.ComponentVersion {
+				return &v1alpha1.ComponentVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-name",
+						Namespace: "default",
+					},
+					Spec: v1alpha1.ComponentVersionSpec{
+						Component: name,
+						Version: v1alpha1.Version{
+							Semver: "<=v0.0.2",
+						},
+						Repository: v1alpha1.Repository{
+							URL: env.repositoryURL,
+						},
+					},
+				}
+			},
+			setupComponents: func(name string) error {
+				for _, v := range []string{"v0.0.1", "v0.0.2", "v0.0.3"} {
+					if err := env.AddComponentVersionToRepository(Component{
+						Name:    name,
+						Version: v,
+					}); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			expectedVersion: "v0.0.2",
+		},
+		{
+			name: "using = should still work as expected",
+			componentVersion: func(name string) *v1alpha1.ComponentVersion {
+				return &v1alpha1.ComponentVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-name",
+						Namespace: "default",
+					},
+					Spec: v1alpha1.ComponentVersionSpec{
+						Component: name,
+						Version: v1alpha1.Version{
+							Semver: "=v0.0.1",
+						},
+						Repository: v1alpha1.Repository{
+							URL: env.repositoryURL,
+						},
+					},
+				}
+			},
+			setupComponents: func(name string) error {
+				for _, v := range []string{"v0.0.1", "v0.0.2"} {
+					if err := env.AddComponentVersionToRepository(Component{
+						Name:    name,
+						Version: v,
+					}); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			expectedVersion: "v0.0.1",
 		},
 	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeKubeClient := env.FakeKubeClient()
+			cache := oci.NewClient(strings.TrimPrefix(env.repositoryURL, "http://"))
+			ocmClient := NewClient(fakeKubeClient, cache)
+			component := "github.com/skarlso/ocm-demo-index"
 
-	latest, err := ocmClient.GetLatestComponentVersion(context.Background(), cv)
-	assert.NoError(t, err)
-	assert.Equal(t, "v0.0.5", latest)
+			err := tt.setupComponents(component)
+			require.NoError(t, err)
+			cv := tt.componentVersion(component)
+
+			latest, err := ocmClient.GetLatestValidComponentVersion(context.Background(), cv)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedVersion, latest)
+		})
+	}
 }
 
 func TestClient_VerifyComponent(t *testing.T) {

--- a/pkg/ocm/ocm_test.go
+++ b/pkg/ocm/ocm_test.go
@@ -152,7 +152,8 @@ func TestClient_GetLatestValidComponentVersion(t *testing.T) {
 				}
 			},
 			setupComponents: func(name string) error {
-				for _, v := range []string{"v0.0.5"} {
+				// v0.0.1 should not be chosen.
+				for _, v := range []string{"v0.0.1", "v0.0.5"} {
 					if err := env.AddComponentVersionToRepository(Component{
 						Name:    name,
 						Version: v,


### PR DESCRIPTION
## Problem

- you can't define a concrete version to install if the latest version is greater than the version you choose, because we always return the latest
- you can't define a constraint that would still work if the constraint it something like `<=2.0.0` but the latest version is above that like `3.0.0`. It should reconcile `2.0.0` but it will actually error saying, no versions met the constraint
- you can't downgrade. if you change your constraint to `<=2.0.0` from `>2.0.0` nothing will happen

## Solution

Reconcile versions up-to the given constraint. This means that if a constraint is provided, we will return whatever the maximum is that STILL VALIDATES to that constraint. This is achieved by looping through the descending order of versions and returning the first that validates.

Downgrading or pinning to a version will be achieved by saying `v0.1.1` as a constraint. Basically, if a constraint is a version that can be parsed as a correct semver, we will choose that version to install regardless of if it exists or not. ( that will be determined later when we are trying to look up the component version using that version ).