### PR TITLE
Remove references to `regcred` secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ dist/
 output/
 
 tilt-settings.yaml
+.envrc

--- a/Tiltfile
+++ b/Tiltfile
@@ -68,12 +68,6 @@ def create_secrets():
     if not opts.get("enable"):
         return
 
-    k8s_yaml(secret_yaml_registry("regcred", "ocm-system", flags_dict = {
-        'docker-server': 'ghcr.io',
-        'docker-username': opts.get('user'),
-        'docker-email': opts.get('email'),
-        'docker-password': opts.get('token'),
-    }), allow_duplicates = True)
     k8s_yaml(secret_from_dict("creds", "ocm-system", inputs = {
         'username' : opts.get('user'),
         'password' : opts.get('token'),

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -30,15 +30,6 @@ spec:
         image: open-component-model/ocm-controller
         name: manager
         imagePullPolicy: Always
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: SERVICE_ACCOUNT
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.serviceAccountName
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -3,5 +3,3 @@ kind: ServiceAccount
 metadata:
   name: ocm-controller
   namespace: system
-imagePullSecrets:
-- name: regcred


### PR DESCRIPTION
## Description

We no longer require the registry credentials secret to be passed in to
the controller at startup. That means we can remove the reference from
the Service Account, Pod Template and Tiltfile.

Signed-off-by: Piaras Hoban <phoban01@gmail.com>
