### PR TITLE
Bugfix: nil pointer if artifact is missing

### DIFF
--- a/controllers/mutation_reconcile_looper.go
+++ b/controllers/mutation_reconcile_looper.go
@@ -783,7 +783,7 @@ func (m *MutationReconcileLooper) getValues(ctx context.Context, obj *v1alpha1.M
 		fetcher := fetch.NewArchiveFetcher(10, tarSize, tarSize, "")
 		artifact := source.GetArtifact()
 		if artifact == nil {
-			return nil, fmt.Errorf("could not get values artifact")
+			return nil, fmt.Errorf("could not get artifact from source: %s", obj.ValuesFrom.FluxSource.SourceRef.Name)
 		}
 		err = fetcher.Fetch(artifact.URL, source.GetArtifact().Digest, tmpDir)
 		if err != nil {


### PR DESCRIPTION
## Description

Fix a nil pointer that occurred when trying to fetch an non-existent artifact.

Signed-off-by: Piaras Hoban <phoban01@gmail.com>
