### PR TITLE
restrored the reconciling condition

### DIFF
--- a/controllers/componentversion_contoller_test.go
+++ b/controllers/componentversion_contoller_test.go
@@ -146,6 +146,7 @@ func TestComponentVersionReconcileFailure(t *testing.T) {
 			Namespace: cv.Namespace,
 		},
 	})
+	require.NoError(t, err)
 
 	t.Log("verifying updated object status")
 	err = client.Get(context.Background(), types.NamespacedName{


### PR DESCRIPTION
Condition on the ComponentVersion is never set to Ready in case there is another reconciling like a version update or upon a requeue. This pr https://github.com/open-component-model/ocm-controller/pull/207 started to surface that issue. Another test that surfaced it was when I was trying to update the values for MPAS. It never updated it because the ComponentVersion went into Reconiling state and NotReady which made the loop wait, and eventually time out with:

```
2023-06-06T14:48:47Z	ERROR	Reconciliation did not succeed, retrying in 10m0s	{"name": "podinfocomponent-version", "namespace": "mpas-sample-project", "reconciler kind": "ComponentVersion", "annotations": {}, "error": "ProgressingWithRetry"}
github.com/fluxcd/pkg/runtime/events.(*Recorder).AnnotatedEventf
	/Users/skarlso/go/pkg/mod/github.com/fluxcd/pkg/runtime@v0.35.0/events/recorder.go:137
github.com/open-component-model/ocm-controller/pkg/event.New
	/Users/skarlso/goprojects/SAP/ocm-controller/pkg/event/event.go:31
github.com/open-component-model/ocm-controller/controllers.(*ComponentVersionReconciler).Reconcile.func1
	/Users/skarlso/goprojects/SAP/ocm-controller/controllers/componentversion_controller.go:107
github.com/open-component-model/ocm-controller/controllers.(*ComponentVersionReconciler).Reconcile
	/Users/skarlso/goprojects/SAP/ocm-controller/controllers/componentversion_controller.go:152
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/Users/skarlso/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:122
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/Users/skarlso/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:323
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/Users/skarlso/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:274
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/Users/skarlso/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:235
```