### PR TITLE
Improve test stability by actually reading config instead of doing text searches

### DIFF
--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -929,12 +929,11 @@ configuration:
 				args := cache.PushDataCallingArgumentsOnCall(0)
 				assert.Equal(t, "sha-18322151501422808564", args.Name)
 				assert.Equal(t, "999", args.Version)
-				assert.Contains(
-					t,
-					args.Content,
-					"PODINFO_UI_COLOR: bittersweet\n  PODINFO_UI_MESSAGE: this is a new message\n",
-					"the configuration data should have been applied",
-				)
+				sourceFile := extractFileFromTarGz(t, io.NopCloser(bytes.NewBuffer([]byte(args.Content))), "configmap.yaml")
+				configMap := corev1.ConfigMap{}
+				assert.NoError(t, yaml.Unmarshal(sourceFile, &configMap))
+				assert.Equal(t, "bittersweet", configMap.Data["PODINFO_UI_COLOR"])
+				assert.Equal(t, "this is a new message", configMap.Data["PODINFO_UI_MESSAGE"])
 			}
 
 			err = client.Get(context.Background(), types.NamespacedName{


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

Improve test stability by actually reading config instead of doing text searches

See discussion between myself and @Skarlso [here](https://github.com/open-component-model/ocm-controller/pull/425)

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)
> Remove if not applicable

## Screenshots

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Below is a screenshot of the test results.   Results were the same before and after my change.
Note the reason for changing the tests is so that things won't break when I merge [this](https://github.com/dee0sap/ocm/tree/adjust_quote_style_for_yaml_in_localization_as_needed) branch.   That branch cleans up the json vs yaml handling in SubstituteByValue.

![image](https://github.com/open-component-model/ocm-controller/assets/82829708/9db537ec-e2c6-4101-80cd-136a4b0fb233)


## Added to documentation?

- [ ] 📜 README.md
- [x ] 🙅 no documentation needed

## Checklist:

- [ x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] Any dependent changes have been merged and published in downstream modules
