### PR TITLE
Sidequest: Remove technical debt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ lint: golangci-lint ## Run golangci-lint.
 
 ##@ Testing
 
+# Note: Requires tinygo (0.31.2) and wasm-opt
 .PHONY: test
 test: manifests generate fmt vet build-wasm-testdata envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out

--- a/Makefile
+++ b/Makefile
@@ -132,36 +132,6 @@ docker-build: ## Build docker image with the manager.
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}:${TAG}
 
-##@ Deployment
-
-ifndef ignore-not-found
-  ignore-not-found = false
-endif
-
-.PHONY: install
-install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
-
-.PHONY: uninstall
-uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
-
-.PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/default && $(KUSTOMIZE) edit set image open-component-model/ocm-controller=$(IMG):$(TAG)
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
-
-.PHONY: dev-deploy
-dev-deploy: kustomize ## Deploy controller dev image in the configured Kubernetes cluster in ~/.kube/config
-	mkdir -p config/dev && cp -R config/default/* config/dev
-	cd config/dev && $(KUSTOMIZE) edit set image open-component-model/ocm-controller=$(IMG):$(TAG)
-	$(KUSTOMIZE) build config/dev | kubectl apply -f -
-	rm -rf config/dev
-
-.PHONY: undeploy
-undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
-
 ##@ Component
 
 .PHONY: plain-push

--- a/hack/prime_test_cluster.sh
+++ b/hack/prime_test_cluster.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 # cleanup
-rm -fr hack/rootCA.pem
+if [[ -f hack/rootCA.pem ]]; then
+  rm hack/rootCA.pem
+fi
 
 CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION:-v1.13.1}
 
@@ -12,23 +14,23 @@ fi
 
 kind create cluster --name=e2e-test-cluster
 
-echo -n 'installing cert-manager'
+echo 'installing cert-manager'
 kubectl apply -f hack/cert-manager.yaml
 kubectl wait --for=condition=Available=True Deployment/cert-manager -n cert-manager --timeout=60s
 kubectl wait --for=condition=Available=True Deployment/cert-manager-webhook -n cert-manager --timeout=60s
 kubectl wait --for=condition=Available=True Deployment/cert-manager-cainjector -n cert-manager --timeout=60s
 echo 'done'
 
-echo -n 'applying root certificate issuer'
+echo 'applying root certificate issuer'
 kubectl apply -f hack/cluster_issuer.yaml
 echo 'done'
 
-echo -n 'waiting for root certificate to be generated...'
+echo 'waiting for root certificate to be generated...'
 kubectl wait --for=condition=Ready=true Certificate/mpas-bootstrap-certificate -n cert-manager --timeout=60s
 echo 'done'
 
 kubectl get secret ocm-registry-tls-certs -n cert-manager -o jsonpath="{.data['tls\.crt']}" | base64 -d > hack/rootCA.pem
-echo -n 'installing root certificate into local trust store...'
+echo 'installing root certificate into local trust store...'
 CAROOT=hack ./bin/mkcert -install
 rootCAPath="./hack/rootCA.pem"
 


### PR DESCRIPTION
## Description

* the deploy targets do not work anymore since the directory-structure does not exist. This is because the deployment needs an additionaly OCI registry.
To deploy the controller one can use the instructions in the README.md
* add context on how to run `make test`
* cleanup

