### PR TITLE
fix: default the resource version to component version

### DIFF
--- a/controllers/resource_controller.go
+++ b/controllers/resource_controller.go
@@ -205,7 +205,7 @@ func (r *ResourceReconciler) reconcile(
 	// The reader is unused here, but we should still close it, so it's not left over.
 	defer reader.Close()
 
-	version := "latest"
+	version := componentVersion.Status.ReconciledVersion
 	// GetVersion returns resourceRef.Version
 	if obj.Spec.SourceRef.GetVersion() != "" {
 		version = obj.Spec.SourceRef.GetVersion()

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -172,7 +172,8 @@ func (c *Client) GetResource(
 	cv *v1alpha1.ComponentVersion,
 	resource *v1alpha1.ResourceReference,
 ) (io.ReadCloser, string, int64, error) {
-	version := "latest"
+	// we default to the latest component version if we don't have any versions for the resource.
+	version := cv.Status.ReconciledVersion
 	if resource.ElementMeta.Version != "" {
 		version = resource.ElementMeta.Version
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Fixes https://github.com/open-component-model/ocm-controller/issues/629

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->