### PR TITLE
Add node selector in deployments

### DIFF
--- a/deploy/templates/deployment_manager.yaml
+++ b/deploy/templates/deployment_manager.yaml
@@ -69,3 +69,7 @@ spec:
       volumes:
       {{- toYaml .Values.manager.volumes | nindent 8 }}
       {{- end}}
+      {{- if .Values.manager.nodeSelector }}
+      nodeSelector:
+      {{- toYaml .Values.manager.nodeSelector | nindent 8 }}
+      {{- end}}

--- a/deploy/templates/deployment_registry.yaml
+++ b/deploy/templates/deployment_registry.yaml
@@ -55,3 +55,7 @@ spec:
       {{- if .Values.registry.tls.enabled }}
       {{- toYaml .Values.registry.tls.volumes | nindent 8 }}
       {{- end}}
+      {{- if .Values.registry.nodeSelector }}
+      nodeSelector:
+      {{- toYaml .Values.registry.nodeSelector | nindent 8 }}
+      {{- end}}

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -28,6 +28,7 @@ registry:
               path: "key.pem"
             - key: "ca.crt"
               path: "ca.pem"
+  nodeSelector: {}
 
 manager:
   replicaCount: 1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Add `nodeSelector` field in controllers deployments chart.
Users can modify the `nodeSelector` field from Helm.

This PR fixes [this issue](https://github.com/open-component-model/ocm-project/issues/557).
