### PR TITLE
fix indentation for registry deployment resource block

### DIFF
--- a/deploy/templates/deployment_registry.yaml
+++ b/deploy/templates/deployment_registry.yaml
@@ -50,7 +50,7 @@ spec:
             successThreshold: 1
             failureThreshold: 3
           resources:
-          {{- toYaml .Values.registry.resources | nindent 10 }}
+          {{- toYaml .Values.registry.resources | nindent 12 }}
       volumes:
         - name: registry
           emptyDir: {}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Fixes the indentation to the registry deployment resource block when Helm template is overwritten with specific resource limitations.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [issue 581](https://github.com/open-component-model/ocm-project/issues/581)