### PR TITLE
generate bootstrap issuer and certificates in ocm controller helm charts

### DIFF
--- a/deploy/templates/cert.yaml
+++ b/deploy/templates/cert.yaml
@@ -1,11 +1,18 @@
 {{- if .Values.tlsCert.generateTlsCert }}
+
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .Values.tlsCert.defaultSecretName }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Values.tlsCert.bootstrap.certificateName }}
+  namespace: cert-manager
 spec:
-  secretName: {{ .Values.tlsCert.defaultSecretName }}
+  commonName: {{ .Values.tlsCert.bootstrap.commonName }}
+  isCA: true
+  secretName: {{ .Values.tlsCert.bootstrap.secretName }}
+  subject:
+    organizations:
+      - ocm.software
   dnsNames:
     - registry.{{ .Release.Namespace }}.svc.cluster.local
     - localhost
@@ -17,15 +24,51 @@ spec:
     encoding: PKCS8
     size: 2048
   issuerRef:
-    name: {{ .Values.tlsCert.defaultIssuerName }}
+    name: {{ .Values.tlsCert.bootstrap.issuerName }}
     kind: ClusterIssuer
     group: cert-manager.io
+
 ---
+
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: {{ .Values.tlsCert.defaultIssuerName }}
+  name: {{ .Values.tlsCert.bootstrap.issuerName }}
+spec:
+  selfSigned: {}
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.tlsCert.certificateName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ .Values.tlsCert.secretName }}
+  dnsNames:
+    - registry.{{ .Release.Namespace }}.svc.cluster.local
+    - localhost
+  ipAddresses:
+    - 127.0.0.1
+    - ::1
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+    size: 2048
+  issuerRef:
+    name: {{ .Values.tlsCert.issuerName }}
+    kind: ClusterIssuer
+    group: cert-manager.io
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: {{ .Values.tlsCert.issuerName }}
 spec:
   ca:
-    secretName: {{ .Values.tlsCert.defaultSecretName }}
+    secretName: {{ .Values.tlsCert.secretName }}
+
 {{- end}}

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -2,8 +2,16 @@
 tlsCert:
   # If cert-manager is installed, set generateTlsCert to true to generate a cert
   generateTlsCert: false
-  defaultSecretName: &tlsSecretName "ocm-registry-tls-certs"
-  defaultIssuerName: "ocm-certificate-issuer"
+
+  bootstrap:
+    certificateName: "ocm-bootstrap-certificate"
+    issuerName: "ocm-bootstrap-issuer"
+    secretName: &tlsSecretName "ocm-registry-tls-certs"
+    commonName: "cert-manager-ocm-tls"
+
+  certificateName: *tlsSecretName
+  secretName: *tlsSecretName
+  issuerName: "ocm-certificate-issuer"
 
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
We are able to generate certs for ocm registry when the `tlsCert` option is set to true.
However, the bootstrap issuer is missing and not installed.
This PR generate the bootstrap issuer and cert to fix the issue.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [the issue 583](https://github.com/open-component-model/ocm-project/issues/583)