### PR TITLE
fix(registry): change readiness and liveness probe to httpGet /v2

### DIFF
--- a/deploy/templates/deployment_registry.yaml
+++ b/deploy/templates/deployment_registry.yaml
@@ -34,16 +34,20 @@ spec:
           {{- toYaml .Values.registry.tls.volumeMounts | nindent 12 }}
           {{- end}}
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /v2/
               port: 5000
+              scheme: HTTPS
             initialDelaySeconds: 2
             timeoutSeconds: 1
             periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /v2/
               port: 5000
+              scheme: HTTPS
             initialDelaySeconds: 15
             timeoutSeconds: 1
             periodSeconds: 20


### PR DESCRIPTION
#### What this PR does / why we need it

There are lot of error logging and noise in the registry deployment due to TLS errors on the probes

- changing the Liveness and Readiness probes `httpGet` on `/v2` path to avoid TLS handshake errors

Additionally there are noises from OTEL metrics (enabled by default in registry) but they can be overridden with env via values

```yaml
 - name: OTEL_TRACES_EXPORTER
   value: none
```

This is a very small fix and may not fit into v2 controllers but until then it would be nice to get this fix in.