### PR TITLE
fix: rename the helm podinfo deployer as it collides with ocm test

### DIFF
--- a/e2e/helm_test.go
+++ b/e2e/helm_test.go
@@ -62,7 +62,7 @@ func TestHelmChartResource(t *testing.T) {
 		Setup(setup.AddFilesToGitRepository(getHelmManifests(testHelmChartBasedResource, testRepoHelmName)...)).
 		Assess("check that component version is ready and valid", checkIsComponentVersionReady("ocm-with-helm", ocmNamespace))
 
-	validationDeploymentBackend := checkDeploymentReadiness("fluxdeployer-podinfo-pipeline-backend", "ghcr.io/stefanprodan/podinfo")
+	validationDeploymentBackend := checkDeploymentReadiness("fluxdeployer-helm-podinfo-pipeline-backend", "ghcr.io/stefanprodan/podinfo")
 
 	dumpState := features.New("dump cluster state").Teardown(teardown.DumpClusterState(teardown.Controller{
 		LabelSelector: map[string]string{"app": "ocm-controller"},

--- a/e2e/testdata/testHelmChartResource/deployer.yaml
+++ b/e2e/testdata/testHelmChartResource/deployer.yaml
@@ -1,7 +1,7 @@
 apiVersion: delivery.ocm.software/v1alpha1
 kind: FluxDeployer
 metadata:
-  name: fluxdeployer-podinfo-pipeline-backend
+  name: fluxdeployer-helm-podinfo-pipeline-backend
   namespace: ocm-system
 spec:
   interval: 5s


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->