### PR TITLE
fix: manually set client-side ratelimiting to previous values

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,6 +117,11 @@ func main() {
 	glog.SetLevel(glog.WARNING, "yq-lib")
 
 	restConfig := ctrl.GetConfigOrDie()
+	// Stop enabling client-side ratelimiter by default (https://github.com/kubernetes-sigs/controller-runtime/pull/3119)
+	// Previous behavior can be preserved by setting QPS 20 and Burst 30 on the rest.Config
+	restConfig.Burst = 30
+	restConfig.QPS = 20
+
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Fixes https://github.com/open-component-model/ocm-project/issues/684

#### Which issue(s) this PR is related to
<!--
Usage: `Related to #<issue number>`, or `Related to (paste link of issue)`.
-->