### PR TITLE
chore: update go to 1.26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ GEN_CRD_API_REFERENCE_DOCS ?= $(LOCALBIN)/gen-crd-api-reference-docs
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.19.0
+CONTROLLER_TOOLS_VERSION ?= v0.20.1
 GEN_API_REF_DOCS_VERSION ?= e327d0730470cbd61b06300f81c5fcf91c23c113
 MKCERT_VERSION ?= v1.4.4
 GOLANGCI_LINT_VERSION ?= v2.11.2
@@ -184,7 +184,7 @@ $(GEN_CRD_API_REFERENCE_DOCS): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-23
 
 .PHONY: test-summary-tool
 test-summary-tool: ## Download gotestsum locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ $(GEN_CRD_API_REFERENCE_DOCS): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-23
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.23
 
 .PHONY: test-summary-tool
 test-summary-tool: ## Download gotestsum locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.19.0
 GEN_API_REF_DOCS_VERSION ?= e327d0730470cbd61b06300f81c5fcf91c23c113
 MKCERT_VERSION ?= v1.4.4
-GOLANGCI_LINT_VERSION ?= v2.5.0
+GOLANGCI_LINT_VERSION ?= v2.11.2
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/controllers/resource_controller.go
+++ b/controllers/resource_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/fluxcd/pkg/apis/meta"
@@ -291,9 +292,7 @@ func (r *ResourceReconciler) constructIdentity(
 		v1alpha1.ResourceNameKey:     obj.Spec.SourceRef.ResourceRef.Name,
 		v1alpha1.ResourceVersionKey:  version,
 	}
-	for k, v := range obj.Spec.SourceRef.ResourceRef.ExtraIdentity {
-		identity[k] = v
-	}
+	maps.Copy(identity, obj.Spec.SourceRef.ResourceRef.ExtraIdentity)
 
 	if len(obj.Spec.SourceRef.ResourceRef.ReferencePath) > 0 {
 		var builder strings.Builder

--- a/deploy/crds/delivery.ocm.software_componentdescriptors.yaml
+++ b/deploy/crds/delivery.ocm.software_componentdescriptors.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: componentdescriptors.delivery.ocm.software
 spec:
   group: delivery.ocm.software

--- a/deploy/crds/delivery.ocm.software_componentversions.yaml
+++ b/deploy/crds/delivery.ocm.software_componentversions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: componentversions.delivery.ocm.software
 spec:
   group: delivery.ocm.software

--- a/deploy/crds/delivery.ocm.software_configurations.yaml
+++ b/deploy/crds/delivery.ocm.software_configurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: configurations.delivery.ocm.software
 spec:
   group: delivery.ocm.software

--- a/deploy/crds/delivery.ocm.software_fluxdeployers.yaml
+++ b/deploy/crds/delivery.ocm.software_fluxdeployers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: fluxdeployers.delivery.ocm.software
 spec:
   group: delivery.ocm.software

--- a/deploy/crds/delivery.ocm.software_localizations.yaml
+++ b/deploy/crds/delivery.ocm.software_localizations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: localizations.delivery.ocm.software
 spec:
   group: delivery.ocm.software

--- a/deploy/crds/delivery.ocm.software_resources.yaml
+++ b/deploy/crds/delivery.ocm.software_resources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: resources.delivery.ocm.software
 spec:
   group: delivery.ocm.software

--- a/deploy/crds/delivery.ocm.software_snapshots.yaml
+++ b/deploy/crds/delivery.ocm.software_snapshots.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: snapshots.delivery.ocm.software
 spec:
   group: delivery.ocm.software

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-component-model/ocm-controller
 
-go 1.25.7
+go 1.26.1
 
 // flux dependent rewrite
 replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.1-0.20220411205349-bde1400a84be

--- a/pkg/configdata/configdata.go
+++ b/pkg/configdata/configdata.go
@@ -68,8 +68,8 @@ localization:
 // - **tag**.
 type ConfigData struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Configuration     ConfigurationSpec  `json:"configuration,omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
+	Configuration     ConfigurationSpec  `json:"configuration,omitzero"`
 	Localization      []LocalizationRule `json:"localization,omitempty"`
 }
 

--- a/pkg/oci/repository.go
+++ b/pkg/oci/repository.go
@@ -142,7 +142,7 @@ func (c *Client) setupCertificates(ctx context.Context) error {
 }
 
 func (c *Client) constructTLSRoundTripper() http.RoundTripper {
-	tlsConfig := &tls.Config{} //nolint:gosec // must provide lower version for quay.io
+	tlsConfig := &tls.Config{}
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(c.ca)
 

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"sort"
 	"strings"
@@ -198,9 +199,7 @@ func (c *Client) GetResource(
 	}
 
 	// Add extra identity.
-	for k, v := range resource.ElementMeta.ExtraIdentity {
-		identity[k] = v
-	}
+	maps.Copy(identity, resource.ElementMeta.ExtraIdentity)
 	if len(resource.ReferencePath) > 0 {
 		var builder strings.Builder
 		for _, path := range resource.ReferencePath {

--- a/pkg/snapshot/tar.go
+++ b/pkg/snapshot/tar.go
@@ -70,7 +70,7 @@ func buildTar(artifactPath, sourceDir string) error {
 		if !fi.Mode().IsRegular() {
 			return nil
 		}
-		f, err := os.Open(p)
+		f, err := os.Open(p) //nolint:gosec // path is validated by filepath.Walk which skips symlinks
 		if err != nil {
 			f.Close()
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Update to go 1.26 as dependencies require a new go version

#### Which issue(s) this PR is related to
<!--
Usage: `Related to #<issue number>`, or `Related to (paste link of issue)`.
-->