### PR TITLE
chore(GHA): adjust trigger and runner

### DIFF
--- a/.github/workflows/check-manifest-generation-diff.yaml
+++ b/.github/workflows/check-manifest-generation-diff.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   diff-check-manifests:
     name: Check for diff
-    runs-on: large_runner
+    runs-on: ubuntu-latest
     steps:
     - name: Self Hosted Runner Post Job Cleanup Action
       uses: TooMuch4U/actions-clean@9b358e33df99574ac0bdf2e92fa3db1ae1415563

--- a/.github/workflows/components.yaml
+++ b/.github/workflows/components.yaml
@@ -3,7 +3,7 @@ name: component CTFs
 on:
   pull_request:
     branches:
-      -main
+      - main
   push:
     branches:
       - main
@@ -17,7 +17,7 @@ permissions:
 jobs:
   build-cli:
     name: Build component
-    runs-on: large_runner
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,17 +2,10 @@ name: e2e
 
 on:
   pull_request:
-    paths-ignore:
-      - 'CODE_OF_CONDUCT.md'
-      - 'README.md'
-      - 'Contributing.md'
-      - '.github/workflows/**'
     branches:
       - main
 
   push:
-    paths-ignore:
-      - '.github/workflows/**'
     branches:
       - main
   schedule:
@@ -25,7 +18,7 @@ permissions:
 
 jobs:
   run-e2e-suite:
-    runs-on: large_runner
+    runs-on: ubuntu-latest
     steps:
       - name: Self Hosted Runner Post Job Cleanup Action
         uses: TooMuch4U/actions-clean@9b358e33df99574ac0bdf2e92fa3db1ae1415563

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
   release:
     needs: tests
     name: Trigger release build
-    runs-on: large_runner
+    runs-on: ubuntu-latest
     permissions:
       contents: 'write'
       id-token: 'write'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,16 +2,11 @@ name: test and lint
 
 on:
   pull_request:
-    paths-ignore:
-      - 'CODE_OF_CONDUCT.md'
-      - 'README.md'
-      - 'Contributing.md'
-      - '.github/workflows/**'
+    branches:
+      - main
   workflow_call:
 
   push:
-    paths-ignore:
-      - '.github/workflows/**'
     branches:
       - main
 
@@ -20,7 +15,7 @@ permissions:
 
 jobs:
   run-test-suite:
-    runs-on: large_runner
+    runs-on: ubuntu-latest
     steps:
       - name: Self Hosted Runner Post Job Cleanup Action
         uses: TooMuch4U/actions-clean@9b358e33df99574ac0bdf2e92fa3db1ae1415563


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

I adjusted the branch protection rule to wait for status checks. Unfortunately, not every required workflow is triggered, e.g. for changes in `.github/workflows/**`. We have three possibilities now:
1. Remove required status checks
2. Add a required `Completion` job (see open-component-model/open-component-model)
3. Remove the `path-ignores` section from the workflow triggers

I decided to follow 3. as it is the least effort, adds no complexity, and does not need to be maintained. Currently, most PRs are version bumps that are created in the night and have enough time to run all the workflows.

Additionally, I replaced the `large_runners` with `ubuntu-latest` as we shouldn't use the "big" runners.