### PR TITLE
feat: add custom annotations to pods

### DIFF
--- a/deploy/templates/deployment_manager.yaml
+++ b/deploy/templates/deployment_manager.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        {{- with .Values.manager.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         app: ocm-controller
     spec:

--- a/deploy/templates/deployment_registry.yaml
+++ b/deploy/templates/deployment_registry.yaml
@@ -12,6 +12,10 @@ spec:
       app: registry
   template:
     metadata:
+      {{- with .Values.registry.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: registry
     spec:

--- a/deploy/templates/service_monitoring.yaml
+++ b/deploy/templates/service_monitoring.yaml
@@ -12,6 +12,10 @@ metadata:
     app.kubernetes.io/part-of: ocm-controller
     app.kubernetes.io/managed-by: kustomize
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.monitoring.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
     - port: 8080

--- a/deploy/templates/service_registry.yaml
+++ b/deploy/templates/service_registry.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: registry
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.registry.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     app: registry

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -53,6 +53,10 @@ registry:
       cpu: 200m
       memory: 512Mi
   nodeSelector: {}
+  # Extra annotations merged into the registry pod template metadata.
+  podAnnotations: {}
+  # Extra annotations merged into the registry Service metadata.
+  serviceAnnotations: {}
 
 manager:
   replicaCount: 1
@@ -91,6 +95,12 @@ manager:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Extra annotations merged into the manager pod template metadata.
+  # Useful for things like:
+  #   prometheus.io/scrape: "true"
+  #   prometheus.io/port: "8080"
+  #   prometheus.io/path: "/metrics"
+  podAnnotations: {}
   clusterRole:
     labels:
       # Users can add custom labels here
@@ -142,3 +152,5 @@ manager:
 
 monitoring:
   enabled: false
+  # Extra annotations merged into the metrics Service metadata.
+  serviceAnnotations: {}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

To use these values either use the CLI:

Manager pod scrape annotations:

```
  helm upgrade --install ocm-controller ./deploy \
    --namespace ocm-system --create-namespace \
    --set 'manager.podAnnotations.prometheus\.io/scrape=true' \
    --set 'manager.podAnnotations.prometheus\.io/port=8080' \
    --set 'manager.podAnnotations.prometheus\.io/path=/metrics'
```

Metrics Service scrape annotations (service-based discovery, requires monitoring.enabled=true):

```
  helm upgrade --install ocm-controller ./deploy \
    --namespace ocm-system --create-namespace \
    --set monitoring.enabled=true \
    --set 'monitoring.serviceAnnotations.prometheus\.io/scrape=true' \
    --set 'monitoring.serviceAnnotations.prometheus\.io/port=8080' \
    --set 'monitoring.serviceAnnotations.prometheus\.io/path=/metrics'
```

Registry pod and service annotations together:

```
  helm upgrade --install ocm-controller ./deploy \
    --namespace ocm-system --create-namespace \
    --set 'registry.podAnnotations.prometheus\.io/scrape=false' \
    --set 'registry.serviceAnnotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal=true'
```

Or set these in the values.yaml file.

#### Which issue(s) this PR is related to

Fixes https://github.com/open-component-model/ocm-controller/issues/913