### PR TITLE
feat: Add duration and renewBefore configuration for TLS certificates

### DIFF
--- a/deploy/templates/cert.yaml
+++ b/deploy/templates/cert.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   commonName: {{ .Values.tlsCert.bootstrap.commonName }}
   isCA: true
+  duration: {{ .Values.tlsCert.bootstrap.duration }}
+  renewBefore: {{ .Values.tlsCert.bootstrap.renewBefore }}
   secretName: {{ .Values.tlsCert.bootstrap.secretName }}
   subject:
     organizations:
@@ -46,6 +48,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   secretName: {{ .Values.tlsCert.secretName }}
+  duration: {{ .Values.tlsCert.duration }}
+  renewBefore: {{ .Values.tlsCert.renewBefore }}
   dnsNames:
     - registry.{{ .Release.Namespace }}.svc.cluster.local
     - localhost

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -8,10 +8,14 @@ tlsCert:
     issuerName: "ocm-bootstrap-issuer"
     secretName: &tlsSecretName "ocm-registry-tls-certs"
     commonName: "cert-manager-ocm-tls"
+    duration: "2160h"    # 90 days
+    renewBefore: "720h"  # 30 days before expiry
 
   certificateName: *tlsSecretName
   secretName: *tlsSecretName
   issuerName: "ocm-certificate-issuer"
+  duration: "720h"       # 30 days
+  renewBefore: "288h"    # 12 days before expiry
 
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.


### PR DESCRIPTION
## Summary

- Add configurable `duration` and `renewBefore` fields to both the root CA and leaf Certificate resources in the Helm chart
- Set sensible defaults: root CA (90d duration, renew 30d before expiry), leaf (30d duration, renew 12d before expiry)
- Ensures leaf certificates cannot outlive the root CA after renewal timing drift

## Motivation

Without explicit `duration`/`renewBefore`, certificates rely on cert-manager defaults. This can lead to a scenario where the leaf certificate's validity extends beyond the root CA's expiry — at which point the leaf is considered invalid regardless of its own NotAfter date, causing TLS failures.

The defaults follow a proven pattern:
- Leaf expiry = root CA's renewal window (90 - 60 = 30 days)
- Leaf renewBefore = 40% safety margin on the renewal window (40% × 30 = 12 days)

## Changes

- `deploy/values.yaml`: Added `duration` and `renewBefore` under `tlsCert.bootstrap` (root CA) and `tlsCert` (leaf)
- `deploy/templates/cert.yaml`: Render the new values into both Certificate specs

## Test plan

- [x] `helm template` with `tlsCert.generateTlsCert=true` renders both certificates with correct duration/renewBefore values

Closes open-component-model/ocm#1998