### PR TITLE
chore(fix): fix go releaser not using the root as build context

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,17 +1,19 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+version: 2
 before:
   hooks:
     - go mod tidy
 builds:
-  - main: main.go
-    env:
+  - env:
       - CGO_ENABLED=0
     goos:
       - linux
       - darwin
     goarch:
       - amd64
+    flags:
+      - -tags=
 archives:
   - name_template: >-
       {{ .ProjectName }}_


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Go releaser was building by only using main.go and failed because now we have the pprof files as an extra and it didn't see those.

#### Which issue(s) this PR is related to
<!--
Usage: `Related to #<issue number>`, or `Related to (paste link of issue)`.
-->